### PR TITLE
feat: adds simple fallback logo

### DIFF
--- a/app/prover/[machineId]/page.tsx
+++ b/app/prover/[machineId]/page.tsx
@@ -27,7 +27,7 @@ import {
   MetricValue,
 } from "@/components/ui/metric"
 
-import { SITE_NAME } from "@/lib/constants"
+import { FALLBACK_PROVER_LOGO_SRC, SITE_NAME } from "@/lib/constants"
 
 import { columns } from "./columns"
 
@@ -135,15 +135,13 @@ export default async function ProverPage({ params }: ProverPageProps) {
       <HeroSection>
         <HeroTitle className="h-20 items-center gap-6">
           <div className="relative h-20 w-56">
-            {machine.logo_url && (
-              <Image
-                src={machine.logo_url}
-                alt={`${machine.machine_name} logo`}
-                fill
-                sizes="100vw"
-                className="object-contain object-left"
-              />
-            )}
+            <Image
+              src={machine.logo_url || FALLBACK_PROVER_LOGO_SRC}
+              alt={`${machine.machine_name || "Prover"} logo`}
+              fill
+              sizes="100vw"
+              className="object-contain object-left"
+            />
           </div>
           <h1 className="font-mono text-3xl font-semibold">
             {machine.machine_name}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,3 +3,5 @@ export const SITE_DESCRIPTION = "Building a fully SNARKed Ethereum"
 export const SITE_URL = "https://ethproofs.org"
 export const SITE_PREVIEW_URL = "http://ethproofs.netlify.app"
 export const SITE_REPO_URL = "https://github.com/ethproofs/ethproofs"
+export const FALLBACK_PROVER_LOGO_SRC =
+  "https://ibkqxhjnroghhtfyualc.supabase.co/storage/v1/object/public/public-assets/fallback-prover-logo.svg"


### PR DESCRIPTION
- Fixes cases where provers had no logo
- The link to the prover currently wraps the logo, which disappeared without a log. Fixed with PR.
- image can be updated via db storage