### PR TITLE
`lib/proofs.ts` usage

### DIFF
--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -74,7 +74,7 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
     header: "avg. cost/proof",
     cell: ({ cell }) => {
       const proofs = cell.getValue() as Proof[]
-      if (!proofs.length) return "-"
+      if (!proofs.length) return null
 
       const avgCostPerProof = getProofsAvgCost(proofs)
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,4 +5,3 @@ export const SITE_PREVIEW_URL = "http://ethproofs.netlify.app"
 export const SITE_REPO_URL = "https://github.com/ethproofs/ethproofs"
 export const FALLBACK_PROVER_LOGO_SRC =
   "https://ibkqxhjnroghhtfyualc.supabase.co/storage/v1/object/public/public-assets/fallback-prover-logo.svg"
-export const EMPTY_VALUE = "-"


### PR DESCRIPTION
## Description
- Updates "average cost per proof" to use the helper function `getProofsAvgCost` which calculates this based on `proving_cost` instead of `gas_used` (which is a block value, not a proof value)
- Removes duplicated logic for calculating average proof latency, using `getProofsAvgLatency` helper instead