### PR TITLE
feat: add metadataBase with env SITE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # RPC URL
 RPC_URL=your-rpc-url
+
+# Site URL override
+SITE_URL=https://localhost:3000

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,6 +1,6 @@
 export const SITE_NAME = "EthProofs"
 export const SITE_DESCRIPTION = "Building a fully SNARKed Ethereum"
-export const SITE_URL = "https://ethproofs.org"
+export const SITE_URL = process.env.SITE_URL || "https://ethproofs.org"
 export const SITE_PREVIEW_URL = "http://ethproofs.netlify.app"
 export const SITE_REPO_URL = "https://github.com/ethproofs/ethproofs"
 

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -22,6 +22,7 @@ export const defaults = (custom: CustomMetadata): Metadata => {
   ]
 
   return {
+    metadataBase: new URL(SITE_URL),
     title,
     description,
     openGraph: {


### PR DESCRIPTION
https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase

- Returns `metadataBase` property to `metadata.ts`, required for using relative paths
- Adds SITE_URL as env var with fallback in `constants.ts`
- Updated Netlify with `SITE_URL=https://ethproofs.netlify.app/` during dev; will switch back to production domain when ready