### PR TITLE
fix: formatNumber falls back to "-" if negative

### DIFF
--- a/lib/number.ts
+++ b/lib/number.ts
@@ -1,5 +1,16 @@
+/**
+ * Formats a positive number according to the specified locale and options.
+ *
+ * @param value - The number to format.
+ * @param options - Optional. An object with properties that define how the number should be formatted.
+ * @param locale - Optional. A string with a BCP 47 language tag, or an array of such strings. Defaults to "en-US".
+ * @returns The formatted number as a string. If the value is negative, returns "-".
+ */
 export const formatNumber = (
   value: number,
   options?: Intl.NumberFormatOptions,
   locale = "en-US"
-) => new Intl.NumberFormat(locale, options).format(value)
+) => {
+  if (value < 0) return "-"
+  return new Intl.NumberFormat(locale, options).format(value)
+}


### PR DESCRIPTION
Metrics will always be positive values. This handles case where certain calculations such as "slot" and "epoch" could go negative, in which case these should just fall back to display null value

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/db456c83-5b15-4c5a-b7ae-73cf4713054e">
