### PR TITLE
Block hash param

### DIFF
--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -48,3 +48,12 @@ export const fetchBlockData = async (block_number: number) => {
     hash: block.hash,
   }
 }
+
+/**
+ * Determines the type of value for a given block.
+ *
+ * @param block - The block parameter to evaluate.
+ * @returns A string indicating the type of value: "hash" if the block number is greater than 0xffffffff, otherwise "block_number".
+ */
+export const getBlockValueType = (block: number) =>
+  block > 0xffffffff ? "hash" : "block_number"


### PR DESCRIPTION
Typical block explorers don't only accept the block _number_ in their `/block/<block>` paths, but also the block _hash_. Updates to evaluate the `block` number value being passed; if less than 32-bits (0xffffffff), treated as a `block_number`, else treated as `hash` when fetching a matching block.

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/ab639542-c0b9-40bd-8e3a-c1d6af23a59a">
