### PR TITLE
fix: use length 64 for hash

### DIFF
--- a/seed.ts
+++ b/seed.ts
@@ -34,7 +34,7 @@ const main = async () => {
 
   const { blocks } = await seed.blocks((x) =>
     x(2000, () => ({
-      hash: () => "0x" + faker.git.commitSha(),
+      hash: () => "0x" + faker.git.commitSha({ length: 64 }),
       timestamp: () => faker.date.recent().toISOString(),
     }))
   )


### PR DESCRIPTION
@pettinarip Not sure how this was truncating to 40 before, but I see the following in my `.snaplet/dataModel.json`:

```json
        {
          "id": "storage.migrations.hash",
          "name": "hash",
          "columnName": "hash",
          "type": "varchar",
          "isRequired": true,
          "kind": "scalar",
          "isList": false,
          "isGenerated": false,
          "sequence": false,
          "hasDefaultValue": false,
          "isId": false,
          "maxLength": 40 // <--
        },
```

Not sure how to update this, or if that's necessary, but a block hash will be 64 hex characters (256-bit, 32-byte).