### PR TITLE
Sort tables by block_number desc

### DIFF
--- a/app/prover/[teamId]/page.tsx
+++ b/app/prover/[teamId]/page.tsx
@@ -212,6 +212,7 @@ export default async function ProverPage({ params }: ProverPageProps) {
           // className="" // TODO: Style data table
           columns={columns}
           data={proofs}
+          sorting={[{ id: "block_number", desc: true }]}
         />
       </section>
 

--- a/components/BlocksTable/index.tsx
+++ b/components/BlocksTable/index.tsx
@@ -69,7 +69,14 @@ const BlocksTable = ({ blocks, className }: Props) => {
 
   const blockData = state.allIds.map((id) => state.byId[id])
 
-  return <DataTable className={className} columns={columns} data={blockData} />
+  return (
+    <DataTable
+      className={className}
+      columns={columns}
+      data={blockData}
+      sorting={[{ id: "block_number", desc: true }]}
+    />
+  )
 }
 
 export default BlocksTable

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -5,6 +5,7 @@ import {
   flexRender,
   getCoreRowModel,
   getPaginationRowModel,
+  getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table"
 
@@ -25,22 +26,28 @@ type Props<TData, TValue> = {
   className?: string
   data: TData[]
   columns: ColumnDef<TData, TValue>[]
+  sorting?: { id: string; desc: boolean }[]
 }
 
 const DataTable = <TData, TValue>({
   data,
   columns,
   className,
+  sorting = [],
 }: Props<TData, TValue>) => {
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     initialState: {
       pagination: {
         pageSize: 15,
       },
+    },
+    state: {
+      sorting,
     },
   })
 


### PR DESCRIPTION
This also help with the realtime updates. At this moment, when we receive a new block we are appending it, leaving it at the bottom of the list. Having a client side sorting will help us prevent this issue and always display the blocks in the correct place.