### PR TITLE
"Latency" patches

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
+import prettyMilliseconds from "pretty-ms"
 
 import type { Metric } from "@/lib/types"
 
@@ -370,13 +371,11 @@ export default async function BlockDetailsPage({
                     </MetricInfo>
                   </MetricLabel>
                   <MetricValue>
-                    {proof_latency
-                      ? formatNumber(proof_latency, {
-                          style: "unit",
-                        unit: "second",
-                          unitDisplay: "narrow",
-                        })
-                      : <Null />}
+                    {proof_latency ? (
+                      prettyMilliseconds(proof_latency)
+                    ) : (
+                      <Null />
+                    )}
                   </MetricValue>
                 </MetricBox>
                 <MetricBox

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import Image from "next/image"
+import prettyMilliseconds from "pretty-ms"
 
 import type { SummaryItem } from "@/lib/types"
 
@@ -55,12 +56,7 @@ export default async function Index() {
         {
           label: "Avg proof latency",
           icon: <Clock />,
-          value: formatNumber(recentSummary.data?.avg_proof_latency || 0, {
-            style: "unit",
-            unit: "second",
-            unitDisplay: "narrow",
-            maximumFractionDigits: 0,
-          }),
+          value: prettyMilliseconds(recentSummary.data?.avg_proof_latency || 0),
         },
       ]
     : []

--- a/app/prover/[teamId]/columns.tsx
+++ b/app/prover/[teamId]/columns.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import prettyMilliseconds from "pretty-ms"
 import { ColumnDef } from "@tanstack/react-table"
 
 import type { Proof } from "@/lib/types"
@@ -62,7 +63,7 @@ export const columns: ColumnDef<Proof>[] = [
 
       if (!latency) return <Null />
 
-      return `${latency}s`
+      return prettyMilliseconds(latency)
     },
   },
   // Cost (USD)

--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -314,7 +314,7 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
       const getBestLatency = () => {
         if (!completedProofs.length) return <Null />
 
-        return prettyMilliseconds(fastestProof.proof_latency! * 1e3)
+        return prettyMilliseconds(fastestProof.proof_latency!)
       }
 
       const getAverageLatency = () => {

--- a/docs/api-v0.md
+++ b/docs/api-v0.md
@@ -65,7 +65,7 @@ For `proof_status: "proved"`:
   "proof_status": "proved",
   "proof_id": number (optional),
   "proof": string,
-  "proof_latency": number, // in seconds
+  "proof_latency": number, // in milliseconds
   "proving_cost": number, // in USD
   "proving_cycles": number
 }

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -1,14 +1,18 @@
 import type { Proof } from "./types"
 
+export const isCompleted = (proof: Proof) => proof.proof_status === "proved"
+
 /**
  * Calculates the average latency of an array of proofs.
+ * Filters to completed proofs; other statuses do not yet have a latency
  *
  * @param {Proof[]} proofs - An array of proof objects.
  * @returns {number} - The average latency of the proofs.
  */
 export const getProofsAvgLatency = (proofs: Proof[]): number =>
-  proofs.reduce((acc, proof) => acc + (proof.proof_latency || 0), 0) /
-  proofs.length
+  proofs
+    .filter(isCompleted)
+    .reduce((acc, proof) => acc + (proof.proof_latency || 0), 0) / proofs.length
 
 /**
  * Calculates the average proving cost of an array of proofs.
@@ -42,8 +46,6 @@ export const getAvgCostPerTx = (
   avgProofCost: number,
   transactionCount: number
 ): number => avgProofCost / transactionCount
-
-export const isCompleted = (proof: Proof) => proof.proof_status === "proved"
 
 export const filterCompleted = (proofs: Proof[]) => ({
   completedProofs: proofs.filter(isCompleted),


### PR DESCRIPTION
- Updates to using milliseconds instead of seconds
- Updates api docs accordingly
- Uses `prettyMilliseconds` to display all time durations in human-readable manner
- Fixes avg latency function; forces `.filter(isCompleted)` to avoid including any proofs that should not have a `proof_latency` in calculation this calculation