### PR TITLE
fix: homepage tooltip copy and spacing

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
+import prettyMilliseconds from "pretty-ms"
 
 import type { Metric } from "@/lib/types"
 
@@ -370,13 +371,11 @@ export default async function BlockDetailsPage({
                     </MetricInfo>
                   </MetricLabel>
                   <MetricValue>
-                    {proof_latency
-                      ? formatNumber(proof_latency, {
-                          style: "unit",
-                        unit: "second",
-                          unitDisplay: "narrow",
-                        })
-                      : <Null />}
+                    {proof_latency ? (
+                      prettyMilliseconds(proof_latency)
+                    ) : (
+                      <Null />
+                    )}
                   </MetricValue>
                 </MetricBox>
                 <MetricBox

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import Image from "next/image"
+import prettyMilliseconds from "pretty-ms"
 
 import type { SummaryItem } from "@/lib/types"
 
@@ -55,12 +56,7 @@ export default async function Index() {
         {
           label: "Avg proof latency",
           icon: <Clock />,
-          value: formatNumber(recentSummary.data?.avg_proof_latency || 0, {
-            style: "unit",
-            unit: "second",
-            unitDisplay: "narrow",
-            maximumFractionDigits: 0,
-          }),
+          value: prettyMilliseconds(recentSummary.data?.avg_proof_latency || 0),
         },
       ]
     : []

--- a/app/prover/[teamId]/columns.tsx
+++ b/app/prover/[teamId]/columns.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import prettyMilliseconds from "pretty-ms"
 import { ColumnDef } from "@tanstack/react-table"
 
 import type { Proof } from "@/lib/types"
@@ -62,7 +63,7 @@ export const columns: ColumnDef<Proof>[] = [
 
       if (!latency) return <Null />
 
-      return `${latency}s`
+      return prettyMilliseconds(latency)
     },
   },
   // Cost (USD)

--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -314,7 +314,7 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
       const getBestLatency = () => {
         if (!completedProofs.length) return <Null />
 
-        return prettyMilliseconds(fastestProof.proof_latency! * 1e3)
+        return prettyMilliseconds(fastestProof.proof_latency!)
       }
 
       const getAverageLatency = () => {

--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -37,18 +37,21 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
     header: () => (
       <div className="text-left">
         block
-        <MetricInfo>
+        <MetricInfo className="space-y-3">
           <TooltipContentHeader>Block height number</TooltipContentHeader>
+          <div className="rounded border bg-background px-3 py-2">
+            <span className="font-mono text-primary">block_number</span>
+          </div>
           <p>
             <span className="font-mono text-primary">block_number</span> value
             from execution block
           </p>
-          <TooltipContentFooter>
-            <p>Time since block published</p>
-            <p>
+          <TooltipContentFooter className="space-y-3">
+            <p className="font-bold">Time since block published</p>
+            <div className="rounded border bg-background px-3 py-2">
               <span className="font-mono text-primary-light">now</span> -{" "}
               <span className="font-mono text-primary-light">timestamp</span>
-            </p>
+            </div>
             <p>
               <span className="font-mono text-primary-light">timestamp</span>{" "}
               value from execution block
@@ -83,19 +86,15 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   {
     accessorKey: "gas_used",
     header: () => (
-      <div className="whitespace-nowrap">
+      <div className="space-y-3 whitespace-nowrap">
         gas usage
         <MetricInfo className="whitespace-normal">
           <TooltipContentHeader>
-            Total gas units executed within block (in millions)
+            Total gas units executed within block
           </TooltipContentHeader>
-          <p>
-            <span className="font-mono text-primary">gas_used</span> /{" "}
-            <span className="font-mono">
-              10
-              <sup>6</sup>
-            </span>
-          </p>
+          <div className="rounded border bg-background px-3 py-2">
+            <span className="font-mono text-primary">gas_used</span>
+          </div>
           <p>
             <span className="font-mono text-primary">gas_used</span> value from
             execution block, expressed in millions
@@ -104,6 +103,22 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
             Proportional to the amount of computational effort a block outputs.
             Less gas = less computationally intense = easier to prove.
           </p>
+          <TooltipContentFooter className="space-y-3">
+            <p className="font-bold">Percentage of block gas limit</p>
+            <div className="rounded border bg-background px-3 py-2">
+              <span className="font-mono text-primary-light">gas_used</span> /{" "}
+              <span className="font-mono text-primary-light">gas_limit</span> x{" "}
+              <span className="font-mono text-primary-light">100</span>
+            </div>
+            <p>
+              <span className="font-mono text-primary-light">gas_used</span>{" "}
+              value from execution block header
+            </p>
+            <p>
+              <span className="font-mono text-primary-light">gas_limit</span>{" "}
+              value from execution block header
+            </p>
+          </TooltipContentFooter>
         </MetricInfo>
       </div>
     ),
@@ -134,12 +149,15 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
     header: () => (
       <div className="whitespace-nowrap">
         cost per proof
-        <MetricInfo className="whitespace-normal">
+        <MetricInfo className="space-y-3 whitespace-normal">
           <TooltipContentHeader>
             Proving costs in USD for entire proof of block
           </TooltipContentHeader>
+          <div className="rounded border bg-background px-3 py-2">
+            <span className="italic">proving costs</span>
+          </div>
           <p>
-            <span className="italic">proving costs</span> - USD costs,
+            <span className="italic">proving costs</span> are in USD,
             self-reported by proving teams
           </p>
         </MetricInfo>
@@ -201,19 +219,22 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
           <TooltipContentHeader>
             Proving costs in USD per million gas units proven
           </TooltipContentHeader>
-          <p>
+          <div className="rounded border bg-background px-3 py-2">
             <span className="italic">proving costs</span> /{" "}
-            <span className="font-mono text-primary">gas_used</span> / 10
-            <sup>6</sup>
-          </p>
+            <span className="font-mono text-primary">gas_used</span> /{" "}
+            <span className="font-mono text-primary">
+              10
+              <sup>6</sup>
+            </span>
+          </div>
 
-          <p className="">
-            <span className="italic">proving costs</span> - USD costs,
+          <p>
+            <span className="italic">proving costs</span> are in USD,
             self-reported by proving teams
           </p>
-          <p className="">
-            <span className="font-mono text-primary">gas_used</span> - value
-            from execution block, expressed in millions
+          <p>
+            <span className="font-mono text-primary">gas_used</span> value from
+            execution block header, expressed in millions
           </p>
           <p className="text-body-secondary">
             Normalized USD cost per gas unit to allow comparison amongst proofs
@@ -276,13 +297,16 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
     header: () => (
       <div className="whitespace-nowrap">
         proving time
-        <MetricInfo className="whitespace-normal">
+        <MetricInfo className="space-y-3 whitespace-normal">
           <TooltipContentHeader>
             Time spent generating proof of execution
           </TooltipContentHeader>
+          <div className="rounded border bg-background px-3 py-2">
+            <span className="italic">proof latency</span>
+          </div>
           <p>
-            <span className="italic">proof latency</span> - duration of proof
-            generation process, self reported by proving teams
+            <span className="italic">proof latency</span> is duration of the
+            proof generation process, self reported by proving teams
           </p>
           <p className="text-body-secondary">
             Duration of time reported by the proving team to generate the proof
@@ -364,19 +388,20 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
             <Box className="self-center text-2xl text-body-secondary" />
             Number of provers who have indicated intent to prove this block.
           </div>
-          <TooltipContentFooter>
+          <TooltipContentFooter className="space-y-3">
             <p className="font-bold">Time to proof (fastest proof shown)</p>
-            <div className="my-2">
+            <div className="rounded border bg-background px-3 py-2">
               <span className="italic">proof submission time</span> -{" "}
-              <span className="font-mono text-body">timestamp</span>
+              <span className="font-mono text-primary-light">timestamp</span>
             </div>
             <p>
-              <span className="italic">proof submission time</span> - timestamp
-              logged by EthProofs when completed proof submitted
+              <span className="italic">proof submission time</span> is the
+              timestamp logged by EthProofs when a completed proof has been
+              submitted
             </p>
             <p>
               <span className="font-mono text-primary-light">timestamp</span>{" "}
-              value from execution block
+              value from execution block header
             </p>
           </TooltipContentFooter>
         </MetricInfo>

--- a/docs/api-v0.md
+++ b/docs/api-v0.md
@@ -65,7 +65,7 @@ For `proof_status: "proved"`:
   "proof_status": "proved",
   "proof_id": number (optional),
   "proof": string,
-  "proof_latency": number, // in seconds
+  "proof_latency": number, // in milliseconds
   "proving_cost": number, // in USD
   "proving_cycles": number
 }

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -1,14 +1,18 @@
 import type { Proof } from "./types"
 
+export const isCompleted = (proof: Proof) => proof.proof_status === "proved"
+
 /**
  * Calculates the average latency of an array of proofs.
+ * Filters to completed proofs; other statuses do not yet have a latency
  *
  * @param {Proof[]} proofs - An array of proof objects.
  * @returns {number} - The average latency of the proofs.
  */
 export const getProofsAvgLatency = (proofs: Proof[]): number =>
-  proofs.reduce((acc, proof) => acc + (proof.proof_latency || 0), 0) /
-  proofs.length
+  proofs
+    .filter(isCompleted)
+    .reduce((acc, proof) => acc + (proof.proof_latency || 0), 0) / proofs.length
 
 /**
  * Calculates the average proving cost of an array of proofs.
@@ -42,8 +46,6 @@ export const getAvgCostPerTx = (
   avgProofCost: number,
   transactionCount: number
 ): number => avgProofCost / transactionCount
-
-export const isCompleted = (proof: Proof) => proof.proof_status === "proved"
 
 export const filterCompleted = (proofs: Proof[]) => ({
   completedProofs: proofs.filter(isCompleted),


### PR DESCRIPTION
- Adds use of `<div className="rounded border bg-background px-3 py-2">` as a "code block"-like container, to consistently show the derivation of each metric
- Italic styling used for database values
- text-primary font-mono used for firm values received from blocks
- Under derivation, each term is identified and briefly explained
- Footer section used to explain any of the secondary metrics for a given column
- Fixes "gas expressed in millions" when we weren't showing it that was in the gas column. Just regular gas units in that column.