### PR TITLE
Tooltip component: desktop ui/tooltip + mobile ui/popover

### DIFF
--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { ComponentProps, Fragment, ReactNode, useEffect } from "react"
+import { Portal } from "@radix-ui/react-portal"
+
+import {
+  Popover as UIPopover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Tooltip as UITooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+import { cn, isMobile } from "@/lib/utils"
+
+import { useDisclosure } from "@/hooks/useDisclosure"
+
+export type TooltipProps = ComponentProps<typeof UIPopover> & {
+  trigger: ReactNode
+  children?: ReactNode
+  className?: string
+  onBeforeOpen?: () => void
+  container?: HTMLElement | null
+}
+
+const Tooltip = ({
+  trigger,
+  children,
+  onBeforeOpen,
+  container,
+  className,
+  ...props
+}: TooltipProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  // Close the popover when the user scrolls.
+  // This is useful for mobile devices where the popover is open by clicking the
+  // trigger, not hovering.
+  useEffect(() => {
+    let originalPosition = 0
+
+    const handleScroll = () => {
+      const delta = window.scrollY - originalPosition
+
+      // Close the popover if the user scrolls more than 80px
+      if (isOpen && Math.abs(delta) > 80) {
+        onClose()
+      }
+    }
+
+    // Add event listener when the popover is open
+    if (isOpen) {
+      window.addEventListener("scroll", handleScroll)
+      originalPosition = window.scrollY
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll)
+    }
+  }, [isOpen, onClose])
+
+  const handleOpen = () => {
+    onBeforeOpen?.()
+    onOpen()
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      handleOpen()
+    } else {
+      onClose()
+    }
+  }
+
+  // Use Popover on mobile devices since the user can't hover
+  const Component = isMobile() ? UIPopover : UITooltip
+  const Provider = isMobile() ? Fragment : TooltipProvider
+  const Trigger = isMobile() ? PopoverTrigger : TooltipTrigger
+  const Content = isMobile() ? PopoverContent : TooltipContent
+
+  return (
+    <Provider>
+      <Component
+        open={isOpen}
+        onOpenChange={handleOpenChange}
+        delayDuration={200}
+        {...props}
+      >
+        <Trigger className="focus-visible:outline-primary-hover focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+          {trigger}
+        </Trigger>
+        <Portal container={container}>
+          <Content
+            side="top"
+            sideOffset={2}
+            className={cn("max-w-80 px-5 text-sm", className)}
+            data-testid="tooltip-popover"
+          >
+            {children}
+          </Content>
+        </Portal>
+      </Component>
+    </Provider>
+  )
+}
+
+export default Tooltip

--- a/components/ui/metric.tsx
+++ b/components/ui/metric.tsx
@@ -1,15 +1,9 @@
 import React from "react"
 
 import InfoCircle from "@/components/svgs/info-circle.svg"
+import Tooltip from "@/components/Tooltip"
 
 import { cn } from "@/lib/utils"
-
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "./tooltip"
 
 const MetricBox = React.forwardRef<
   HTMLDivElement,
@@ -40,22 +34,22 @@ type MetricInfoProps = React.HTMLAttributes<HTMLDivElement> & {
 }
 const MetricInfo = React.forwardRef<HTMLDivElement, MetricInfoProps>(
   ({ trigger, className, children, ...props }, ref) => (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger className="ms-2">
+    <Tooltip
+      trigger={
+        <div className="ms-2">
           {trigger || <InfoCircle className="-mb-0.5" />}
-        </TooltipTrigger>
-        <TooltipContent className="max-w-80 sm:max-w-96">
-          <div
-            ref={ref}
-            className={cn("space-y-2 text-start", className)}
-            {...props}
-          >
-            {children}
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        </div>
+      }
+      className="max-w-80 sm:max-w-96"
+    >
+      <div
+        ref={ref}
+        className={cn("space-y-2 text-start", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </Tooltip>
   )
 )
 MetricInfo.displayName = "MetricInfo"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "w//-72 z-50 rounded-md border bg-background-highlight p-4 text-sm text-body shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverContent, PopoverTrigger }

--- a/hooks/useDisclosure.ts
+++ b/hooks/useDisclosure.ts
@@ -1,0 +1,18 @@
+import { useBoolean } from "usehooks-ts"
+
+/**
+ * Hook that provides a more semantic API for managing the open/close state of a
+ * modal, dropdown, or any other component that can be opened and closed.
+ */
+export const useDisclosure = (defaultValue = false) => {
+  const { value, setTrue, setFalse, toggle, setValue } =
+    useBoolean(defaultValue)
+
+  return {
+    isOpen: value,
+    onOpen: setTrue,
+    onClose: setFalse,
+    onToggle: toggle,
+    setValue,
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const isMobile = (): boolean => {
+  if (typeof window === "undefined") return false
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    window.navigator.userAgent
+  )
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
+    "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-portal": "^1.1.2",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-portal':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-progress':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1387,6 +1393,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.2':
     resolution: {integrity: sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.2':
+    resolution: {integrity: sha512-u2HRUyWW+lOiA2g0Le0tMmT55FGOEWHwPFt1EPfbLly7uXQExFo5duNKqG2DzmFXIdqOeNd+TpE8baHWJCyP9w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6082,6 +6101,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-slot': 1.1.0(@types/react@18.2.48)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      aria-hidden: 1.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.6.0(@types/react@18.2.48)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.48
+      '@types/react-dom': 18.2.18
+
+  '@radix-ui/react-popover@1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.48)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.48)(react@18.2.0)
       aria-hidden: 1.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
## Description
- Adds `ui/popover` from shadcn cli and applies base styling
- Adds `Tooltip` component that conditionally renders a `ui/tooltip` component for desktop, and a `ui/popover` for mobile. Accepts a `trigger` prop as a ReactNode, and `children` as the contents of the popup
- Adds `isMobile` helper util, and `useDisclosure` hook
- Replaces tooltip usage with new component inside `ui/metric` `MetricInfo`

Fixes issue where tooltips were non-functional on mobile with existing setup of always using the `ui/tooltip` component (which relies on hovering, not accessible on mobile)

## Preview link
https://deploy-preview-104--ethproofs.netlify.app/