### PR TITLE
fix: inject team name before zkVM labels

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -386,7 +386,8 @@ export default async function BlockDetailsPage({
                   )}
                 >
                   <MetricLabel>
-                    zk<span className="uppercase">VM</span> cycles
+                    <span className="normal-case">{team?.team_name}</span> zk
+                    <span className="uppercase">VM</span> cycles
                     <MetricInfo>
                       The number of cycles used by the prover to generate the
                       proof.

--- a/app/prover/[teamId]/page.tsx
+++ b/app/prover/[teamId]/page.tsx
@@ -98,7 +98,8 @@ export default async function ProverPage({ params }: ProverPageProps) {
     {
       label: (
         <>
-          Avg zk<span className="uppercase">VM</span> cycles per proof
+          <span className="normal-case">{team.team_name}</span> Avg zk
+          <span className="uppercase">VM</span> cycles per proof
         </>
       ),
       description:


### PR DESCRIPTION
## Description
- injects team name before zkVM labels

## Related issue
- Fixes #98
- Fixes #99

## Preview url
https://deploy-preview-106--ethproofs.netlify.app/