### PR TITLE
Logos and names

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -19,7 +19,6 @@ import Hash from "@/components/svgs/hash.svg"
 import Layers from "@/components/svgs/layers.svg"
 import ProofCircle from "@/components/svgs/proof-circle.svg"
 import TrendingUp from "@/components/svgs/trending-up.svg"
-import TeamLogo from "@/components/TeamLogo"
 import { Button } from "@/components/ui/button"
 import {
   HeroBody,
@@ -40,7 +39,6 @@ import { cn } from "@/lib/utils"
 
 import { timestampToEpoch, timestampToSlot } from "@/lib/beaconchain"
 import { getBlockValueType } from "@/lib/blocks"
-import { Tables } from "@/lib/database.types"
 import {
   intervalToReadable,
   renderTimestamp,
@@ -92,16 +90,6 @@ export default async function BlockDetailsPage({
   const { data: teams } = await supabase.from("teams").select("*")
 
   if (!data || error || !teams) notFound()
-
-  const getProverLogoImgProps = (
-    team: Tables<"teams"> | undefined
-  ): Pick<ImageProps, "src" | "alt"> | null => {
-    if (!team?.logo_url) return null
-    return {
-      src: team.logo_url,
-      alt: `${team.team_name} logo`,
-    }
-  }
 
   const {
     timestamp,
@@ -296,7 +284,6 @@ export default async function BlockDetailsPage({
             user_id,
           }) => {
             const team = teams.find((t) => t.user_id === user_id)
-            const imgProps = getProverLogoImgProps(team)
             return (
               <div
                 className={cn(
@@ -308,15 +295,20 @@ export default async function BlockDetailsPage({
               >
                 <div
                   className={cn(
-                    "relative flex h-14 w-40 self-center",
+                    "relative flex h-full items-center",
                     "col-span-3 col-start-1 row-span-1 row-start-1",
                     "sm:col-span-2 sm:col-start-1 sm:row-span-1 sm:row-start-1",
                     "md:col-span-1 md:col-start-1 md:row-span-1 md:row-start-1"
                   )}
                 >
-                  <Link href={"/prover/" + team?.team_id}>
-                    <TeamLogo src={imgProps?.src} alt={imgProps?.alt} />
-                  </Link>
+                  {team?.team_name && (
+                    <Link
+                      href={"/prover/" + team?.team_id}
+                      className="text-2xl"
+                    >
+                      {team?.team_name}
+                    </Link>
+                  )}
                 </div>
                 <Button
                   variant="outline"

--- a/app/prover/[teamId]/page.tsx
+++ b/app/prover/[teamId]/page.tsx
@@ -27,6 +27,8 @@ import {
   MetricValue,
 } from "@/components/ui/metric"
 
+import { cn } from "@/lib/utils"
+
 import { SITE_NAME } from "@/lib/constants"
 
 import { columns } from "./columns"
@@ -135,7 +137,14 @@ export default async function ProverPage({ params }: ProverPageProps) {
               alt={`${team.team_name || "Prover"} logo`}
             />
           </div>
-          <h1 className="font-mono text-3xl font-semibold">{team.team_name}</h1>
+          <h1
+            className={cn(
+              "font-mono text-3xl font-semibold",
+              team.logo_url && "sr-only"
+            )}
+          >
+            {team.team_name}
+          </h1>
         </HeroTitle>
 
         <HeroDivider />


### PR DESCRIPTION
## Description
- visually hide h1 team name if logo available on `/prover/[teamId]`
- use team name instead of logo on table within `/block/[block]`

## Preview link
https://deploy-preview-108--ethproofs.netlify.app/

## Screenshots

<img width="1587" alt="image" src="https://github.com/user-attachments/assets/9e2bcf59-2a4a-418d-ab5f-a0d94e997031">

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/aa6e0424-6ce8-43cb-a7aa-0b6571943508">

<img width="1478" alt="image" src="https://github.com/user-attachments/assets/166f80c8-c421-4f59-a3cd-051ed113f66c">
