### PR TITLE
fix: text alignment for metric values

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,7 +104,7 @@ export default async function Index() {
                 <p className="font-mono text-2xl text-primary md:text-3xl lg:text-4xl">
                   {icon}
                 </p>
-                <p className="font-mono text-2xl text-primary md:text-3xl lg:text-4xl">
+                <p className="text-center font-mono text-2xl text-primary md:text-3xl lg:text-4xl">
                   {value}
                 </p>
               </div>


### PR DESCRIPTION
<img width="478" alt="image" src="https://github.com/user-attachments/assets/871911c0-fb65-4b2e-8f16-83d3e786116f">

Fixes above, applying `text-center` class