### PR TITLE
Blocks metrics: proofs table

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -468,51 +468,63 @@ export default async function BlockDetailsPage({
                       "md:col-span-1 md:col-start-6 md:row-span-1 md:row-start-1"
                     )}
                   >
-                    <Button
-                      variant="outline"
-                      className={cn(
-                        "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
-                        "disabled:bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40"
-                      )}
-                      isSecondary={!isComplete}
-                      disabled={!isComplete}
-                    >
-                      {proof_status === "proved" && (
-                        <>
-                          <ArrowDown />
-                          <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
-                            Download proof
+                    {proof_status === "proved" && (
+                      <Button
+                        variant="outline"
+                        className={cn(
+                          "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
+                          "disabled:bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40"
+                        )}
+                        isSecondary={!isComplete}
+                        disabled={!isComplete}
+                      >
+                        <ArrowDown />
+                        <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
+                          Download proof
+                        </span>
+                      </Button>
+                    )}
+                    {proof_status === "proving" && (
+                      <Tooltip
+                        content={`${team?.team_name ? team.team_name : "Team"} currently generating proof for this block`}
+                      >
+                        <div
+                          className={cn(
+                            "inline-flex items-center justify-center gap-4 rounded-full border border-solid border-current text-primary [&>svg]:shrink-0",
+                            "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
+                            "bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40",
+                            "flex items-center gap-2"
+                          )}
+                        >
+                          <BoxDashed className="text-primary-dark" />
+                          <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
+                            Proving
                           </span>
-                        </>
-                      )}
-                      {proof_status === "proving" && (
-                        <Tooltip
-                          content={`${team?.team_name ? team.team_name : "Team"} currently generating proof for this block`}
+                        </div>
+                      </Tooltip>
+                    )}
+                    {proof_status === "queued" && (
+                      <Tooltip
+                        content={`${team?.team_name ? team.team_name : "Team"} has indicated intent to prove this block`}
+                      >
+                        <div
+                          className={cn(
+                            "inline-flex items-center justify-center gap-4 rounded-full border border-solid border-current text-primary [&>svg]:shrink-0",
+                            "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
+                            "bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40",
+                            "flex items-center gap-2"
+                          )}
                         >
-                          <div className="flex cursor-default items-center gap-2">
-                            <BoxDashed className="text-primary-dark" />
-                            <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
-                              Proving
-                            </span>
-                          </div>
-                        </Tooltip>
-                      )}
-                      {proof_status === "queued" && (
-                        <Tooltip
-                          content={`${team?.team_name ? team.team_name : "Team"} has indicated intent to prove this block`}
-                        >
-                          <div className="flex cursor-default items-center gap-2">
-                            <Box
-                              strokeWidth="1"
-                              className="text-body-secondary"
-                            />
-                            <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
-                              Queued
-                            </span>
-                          </div>
-                        </Tooltip>
-                      )}
-                    </Button>
+                          <Box
+                            strokeWidth="1"
+                            className="text-body-secondary"
+                          />
+                          <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
+                            Queued
+                          </span>
+                        </div>
+                      </Tooltip>
+                    )}
                   </div>
                   <MetricBox
                     className={cn(

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -12,6 +12,7 @@ import { HidePunctuation } from "@/components/StylePunctuation"
 import ArrowDown from "@/components/svgs/arrow-down.svg"
 import BookOpen from "@/components/svgs/book-open.svg"
 import Box from "@/components/svgs/box.svg"
+import BoxDashed from "@/components/svgs/box-dashed.svg"
 import Clock from "@/components/svgs/clock.svg"
 import Cpu from "@/components/svgs/cpu.svg"
 import DollarSign from "@/components/svgs/dollar-sign.svg"
@@ -20,6 +21,7 @@ import Layers from "@/components/svgs/layers.svg"
 import ProofCircle from "@/components/svgs/proof-circle.svg"
 import Timer from "@/components/svgs/timer.svg"
 import Timestamp from "@/components/Timestamp"
+import Tooltip from "@/components/Tooltip"
 import { Button } from "@/components/ui/button"
 import {
   HeroBody,
@@ -419,13 +421,17 @@ export default async function BlockDetailsPage({
           .map(
             ({
               proof_id,
-              prover_duration,
               proof_latency,
+              proof_status,
+              proved_timestamp,
+              prover_duration,
               proving_cost,
               proving_cycles,
               user_id,
             }) => {
               const team = teams.find((t) => t.user_id === user_id)
+              const downloadDisabled =
+                proof_status !== "proved" || !proved_timestamp
               return (
                 <div
                   className={cn(
@@ -452,20 +458,60 @@ export default async function BlockDetailsPage({
                       </Link>
                     )}
                   </div>
-                  <Button
-                    variant="outline"
+                  <div
                     className={cn(
-                      "ms-auto h-8 w-8 min-w-fit gap-2 self-center text-2xl text-primary",
+                      "ms-auto self-center",
                       "col-span-1 col-start-4 row-span-1 row-start-1",
                       "sm:col-span-2 sm:col-start-3 sm:row-span-1 sm:row-start-1",
                       "md:col-span-1 md:col-start-6 md:row-span-1 md:row-start-1"
                     )}
                   >
-                    <ArrowDown />
-                    <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
-                      Download proof
-                    </span>
-                  </Button>
+                    <Button
+                      variant="outline"
+                      className={cn(
+                        "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
+                        "disabled:bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40"
+                      )}
+                      isSecondary={downloadDisabled}
+                      disabled={downloadDisabled}
+                    >
+                      {proof_status === "proved" && (
+                        <>
+                          <ArrowDown />
+                          <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
+                            Download proof
+                          </span>
+                        </>
+                      )}
+                      {proof_status === "proving" && (
+                        <Tooltip
+                          content={`${team?.team_name ? team.team_name : "Team"} currently generating proof for this block`}
+                        >
+                          <div className="flex cursor-default items-center gap-2">
+                            <BoxDashed className="text-primary-dark" />
+                            <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
+                              Proving
+                            </span>
+                          </div>
+                        </Tooltip>
+                      )}
+                      {proof_status === "queued" && (
+                        <Tooltip
+                          content={`${team?.team_name ? team.team_name : "Team"} has indicated intent to prove this block`}
+                        >
+                          <div className="flex cursor-default items-center gap-2">
+                            <Box
+                              strokeWidth="1"
+                              className="text-body-secondary"
+                            />
+                            <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
+                              Queued
+                            </span>
+                          </div>
+                        </Tooltip>
+                      )}
+                    </Button>
+                  </div>
                   <MetricBox
                     className={cn(
                       "col-span-2 col-start-1 row-span-1 row-start-2",

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -314,7 +314,7 @@ export default async function BlockDetailsPage({
     <div className="space-y-20">
       <HeroSection>
         <HeroTitle>
-          <Box strokeWidth="1" className="text-6xl text-primary" />
+          <Box strokeWidth="1" className="text-6xl text-primary shrink-0" />
           <h1 className="font-mono">
             <p className="text-sm font-normal md:text-lg">Block Height</p>
             <p className="text-3xl font-semibold tracking-wide">

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -421,7 +421,6 @@ export default async function BlockDetailsPage({
               proof_latency,
               proof_status,
               proved_timestamp,
-              prover_duration,
               proving_cost,
               proving_cycles,
               user_id,
@@ -429,6 +428,13 @@ export default async function BlockDetailsPage({
               const team = teams.find((t) => t.user_id === user_id)
               const downloadDisabled =
                 proof_status !== "proved" || !proved_timestamp
+              const timeToProof = proved_timestamp
+                ? Math.max(
+                    new Date(proved_timestamp).getTime() -
+                      new Date(block.timestamp).getTime(),
+                    0
+                  )
+                : 0
               return (
                 <div
                   className={cn(
@@ -517,23 +523,41 @@ export default async function BlockDetailsPage({
                     )}
                   >
                     <MetricLabel>
-                      Time to proof
+                      time to proof
                       <MetricInfo>
-                        The time it took to generate this proof, from when the
-                        proving began to when it was complete.
-                        <br />
-                        (hours : minutes : seconds)
+                        <TooltipContentHeader>
+                          time to proof
+                        </TooltipContentHeader>
+                        <div className="rounded border bg-background px-3 py-2">
+                          <span className="italic">proof submission time</span>{" "}
+                          -{" "}
+                          <span className="font-mono text-primary-light">
+                            timestamp
+                          </span>
+                        </div>
+                        <p>
+                          <span className="italic">proof submission time</span>{" "}
+                          is the timestamp logged by {SITE_NAME} when a
+                          completed proof has been submitted
+                        </p>
+                        <p>
+                          <span className="font-mono text-primary-light">
+                            timestamp
+                          </span>{" "}
+                          value from execution block header
+                        </p>
+                        <p className="text-body-secondary">
+                          Total time delay between execution block timestamp and
+                          completion and publishing of proof
+                        </p>
                       </MetricInfo>
                     </MetricLabel>
-                    <MetricValue
-                      className="font-normal"
-                      title={
-                        prover_duration
-                          ? intervalToReadable(prover_duration as string)
-                          : ""
-                      }
-                    >
-                      {(prover_duration as string) || <Null />}
+                    <MetricValue className="font-normal">
+                      {timeToProof > 0 ? (
+                        prettyMilliseconds(timeToProof)
+                      ) : (
+                        <Null />
+                      )}
                     </MetricValue>
                   </MetricBox>
                   <MetricBox
@@ -544,12 +568,22 @@ export default async function BlockDetailsPage({
                     )}
                   >
                     <MetricLabel>
-                      Latency
+                      proving time
                       <MetricInfo>
-                        Time delay from when a block is published, to when proof
-                        has been posted
-                        <br />
-                        (seconds)
+                        <TooltipContentHeader>
+                          proving time
+                        </TooltipContentHeader>
+                        <div className="rounded border bg-background px-3 py-2">
+                          <span className="italic">proof latency</span>
+                        </div>
+                        <p>
+                          <span className="italic">proof latency</span> is
+                          duration of the proof generation process, self
+                          reported by proving teams
+                        </p>
+                        <p className="text-body-secondary">
+                          Time spent generating proof of execution
+                        </p>
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue className="font-normal">

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -55,6 +55,7 @@ import {
   getProofsAvgCost,
   getProofsAvgLatency,
   getProofsAvgTimeToProof,
+  sortProofsStatusAndTimes,
 } from "@/lib/proofs"
 import { createClient } from "@/utils/supabase/client"
 
@@ -413,11 +414,7 @@ export default async function BlockDetailsPage({
         </h2>
 
         {proofs
-          .sort((a, b) => {
-            if (!a.proof_latency) return 1
-            if (!b.proof_latency) return -1
-            return a.proof_latency - b.proof_latency
-          })
+          .sort(sortProofsStatusAndTimes)
           .map(
             ({
               proof_id,

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -383,7 +383,7 @@ export default async function BlockDetailsPage({
                   {label}
                   <MetricInfo>{description}</MetricInfo>
                 </MetricLabel>
-                <MetricValue>{value}</MetricValue>
+                <MetricValue className="font-normal">{value}</MetricValue>
               </MetricBox>
             ))}
           </div>
@@ -400,7 +400,7 @@ export default async function BlockDetailsPage({
                   {label}
                   <MetricInfo>{description}</MetricInfo>
                 </MetricLabel>
-                <MetricValue>{value}</MetricValue>
+                <MetricValue className="font-normal">{value}</MetricValue>
               </MetricBox>
             ))}
           </div>
@@ -454,7 +454,7 @@ export default async function BlockDetailsPage({
                         href={"/prover/" + team?.team_id}
                         className="text-2xl"
                       >
-                        {team?.team_name}
+                        {team.team_name}
                       </Link>
                     )}
                   </div>
@@ -529,6 +529,7 @@ export default async function BlockDetailsPage({
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue
+                      className="font-normal"
                       title={
                         prover_duration
                           ? intervalToReadable(prover_duration as string)
@@ -554,7 +555,7 @@ export default async function BlockDetailsPage({
                         (seconds)
                       </MetricInfo>
                     </MetricLabel>
-                    <MetricValue>
+                    <MetricValue className="font-normal">
                       {proof_latency ? (
                         prettyMilliseconds(proof_latency)
                       ) : (
@@ -578,6 +579,7 @@ export default async function BlockDetailsPage({
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue
+                      className="font-normal"
                       title={proving_cycles ? formatNumber(proving_cycles) : ""}
                     >
                       {proving_cycles ? (
@@ -607,7 +609,7 @@ export default async function BlockDetailsPage({
                         (USD)
                       </MetricInfo>
                     </MetricLabel>
-                    <MetricValue>
+                    <MetricValue className="font-normal">
                       {proving_cost ? (
                         formatNumber(proving_cost, {
                           style: "currency",

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -426,8 +426,7 @@ export default async function BlockDetailsPage({
               user_id,
             }) => {
               const team = teams.find((t) => t.user_id === user_id)
-              const downloadDisabled =
-                proof_status !== "proved" || !proved_timestamp
+              const isComplete = proof_status === "proved" && !!proved_timestamp
               const timeToProof = proved_timestamp
                 ? Math.max(
                     new Date(proved_timestamp).getTime() -
@@ -475,8 +474,8 @@ export default async function BlockDetailsPage({
                         "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
                         "disabled:bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40"
                       )}
-                      isSecondary={downloadDisabled}
-                      disabled={downloadDisabled}
+                      isSecondary={!isComplete}
+                      disabled={!isComplete}
                     >
                       {proof_status === "proved" && (
                         <>
@@ -553,7 +552,7 @@ export default async function BlockDetailsPage({
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue className="font-normal">
-                      {timeToProof > 0 ? (
+                      {isComplete && timeToProof > 0 ? (
                         prettyMilliseconds(timeToProof)
                       ) : (
                         <Null />
@@ -587,7 +586,7 @@ export default async function BlockDetailsPage({
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue className="font-normal">
-                      {proof_latency ? (
+                      {isComplete && proof_latency ? (
                         prettyMilliseconds(proof_latency)
                       ) : (
                         <Null />
@@ -637,7 +636,7 @@ export default async function BlockDetailsPage({
                       className="font-normal"
                       title={proving_cycles ? formatNumber(proving_cycles) : ""}
                     >
-                      {proving_cycles ? (
+                      {isComplete && proving_cycles ? (
                         formatNumber(proving_cycles, {
                           notation: "compact",
                           compactDisplay: "short",
@@ -678,7 +677,7 @@ export default async function BlockDetailsPage({
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue className="font-normal">
-                      {proving_cost ? (
+                      {isComplete && proving_cost ? (
                         formatNumber(proving_cost, {
                           style: "currency",
                           currency: "USD",

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -605,8 +605,32 @@ export default async function BlockDetailsPage({
                       <span className="normal-case">{team?.team_name}</span> zk
                       <span className="uppercase">VM</span> cycles
                       <MetricInfo>
-                        The number of cycles used by the prover to generate the
-                        proof.
+                        <TooltipContentHeader>
+                          <span className="normal-case">{team?.team_name}</span>{" "}
+                          zk<span className="uppercase">VM</span> cycles
+                        </TooltipContentHeader>
+                        <div className="rounded border bg-background px-3 py-2">
+                          <span className="italic">proving cycles</span>
+                        </div>
+                        <p>
+                          <span className="italic">proving cycles</span> is
+                          self-reported by{" "}
+                          {team?.team_name
+                            ? team.team_name
+                            : "the proving team"}
+                        </p>
+                        <p className="text-body-secondary">
+                          The number of cycles used by{" "}
+                          {team?.team_name
+                            ? team.team_name
+                            : "the proving team"}{" "}
+                          to generate the proof.
+                        </p>
+                        <p className="text-body-secondary">
+                          This number will vary depending on hardware and zkVMs
+                          being used by different provers and should not be
+                          directly compared to other provers.
+                        </p>
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -657,11 +657,24 @@ export default async function BlockDetailsPage({
                     )}
                   >
                     <MetricLabel className="sm:max-md:justify-end">
-                      Proving cost
+                      proving costs
                       <MetricInfo>
-                        The cost of generating this proof.
-                        <br />
-                        (USD)
+                        <TooltipContentHeader>
+                          proving costs
+                        </TooltipContentHeader>
+                        <div className="rounded border bg-background px-3 py-2">
+                          <span className="italic">proving costs</span>
+                        </div>
+                        <p>
+                          <span className="italic">proving costs</span> are in
+                          USD, self-reported by{" "}
+                          {team?.team_name ? team.team_name : "proving team"}
+                        </p>
+                        <p className="text-body-secondary">
+                          Proving costs are in USD, and represent the
+                          self-reported expenditures included in proving this
+                          block
+                        </p>
                       </MetricInfo>
                     </MetricLabel>
                     <MetricValue className="font-normal">

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -472,9 +472,10 @@ export default async function BlockDetailsPage({
                       <Button
                         variant="outline"
                         className={cn(
-                          "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
+                          "aspect-square h-8 w-auto gap-2 self-center text-2xl text-primary",
                           "disabled:bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40"
                         )}
+                        size="icon"
                         isSecondary={!isComplete}
                         disabled={!isComplete}
                       >

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -452,7 +452,7 @@ export default async function BlockDetailsPage({
                     {team?.team_name && (
                       <Link
                         href={"/prover/" + team?.team_id}
-                        className="text-2xl"
+                        className="text-2xl hover:text-primary-light hover:underline"
                       >
                         {team.team_name}
                       </Link>

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -410,166 +410,172 @@ export default async function BlockDetailsPage({
           <ProofCircle /> Proofs
         </h2>
 
-        {proofs.map(
-          ({
-            proof_id,
-            prover_duration,
-            proof_latency,
-            proving_cost,
-            proving_cycles,
-            user_id,
-          }) => {
-            const team = teams.find((t) => t.user_id === user_id)
-            return (
-              <div
-                className={cn(
-                  "grid grid-flow-dense grid-cols-4 grid-rows-3",
-                  "sm:grid-rows-2",
-                  "md:grid-cols-6-auto md:grid-rows-1"
-                )}
-                key={proof_id}
-              >
+        {proofs
+          .sort((a, b) => {
+            if (!a.proof_latency) return 1
+            if (!b.proof_latency) return -1
+            return a.proof_latency - b.proof_latency
+          })
+          .map(
+            ({
+              proof_id,
+              prover_duration,
+              proof_latency,
+              proving_cost,
+              proving_cycles,
+              user_id,
+            }) => {
+              const team = teams.find((t) => t.user_id === user_id)
+              return (
                 <div
                   className={cn(
-                    "relative flex h-full items-center",
-                    "col-span-3 col-start-1 row-span-1 row-start-1",
-                    "sm:col-span-2 sm:col-start-1 sm:row-span-1 sm:row-start-1",
-                    "md:col-span-1 md:col-start-1 md:row-span-1 md:row-start-1"
+                    "grid grid-flow-dense grid-cols-4 grid-rows-3",
+                    "sm:grid-rows-2",
+                    "md:grid-cols-6-auto md:grid-rows-1"
                   )}
+                  key={proof_id}
                 >
-                  {team?.team_name && (
-                    <Link
-                      href={"/prover/" + team?.team_id}
-                      className="text-2xl"
+                  <div
+                    className={cn(
+                      "relative flex h-full items-center",
+                      "col-span-3 col-start-1 row-span-1 row-start-1",
+                      "sm:col-span-2 sm:col-start-1 sm:row-span-1 sm:row-start-1",
+                      "md:col-span-1 md:col-start-1 md:row-span-1 md:row-start-1"
+                    )}
+                  >
+                    {team?.team_name && (
+                      <Link
+                        href={"/prover/" + team?.team_id}
+                        className="text-2xl"
+                      >
+                        {team?.team_name}
+                      </Link>
+                    )}
+                  </div>
+                  <Button
+                    variant="outline"
+                    className={cn(
+                      "ms-auto h-8 w-8 min-w-fit gap-2 self-center text-2xl text-primary",
+                      "col-span-1 col-start-4 row-span-1 row-start-1",
+                      "sm:col-span-2 sm:col-start-3 sm:row-span-1 sm:row-start-1",
+                      "md:col-span-1 md:col-start-6 md:row-span-1 md:row-start-1"
+                    )}
+                  >
+                    <ArrowDown />
+                    <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
+                      Download proof
+                    </span>
+                  </Button>
+                  <MetricBox
+                    className={cn(
+                      "col-span-2 col-start-1 row-span-1 row-start-2",
+                      "sm:col-span-1 sm:col-start-1 sm:row-span-1 sm:row-start-2",
+                      "md:col-span-1 md:col-start-2 md:row-span-1 md:row-start-1"
+                    )}
+                  >
+                    <MetricLabel>
+                      Time to proof
+                      <MetricInfo>
+                        The time it took to generate this proof, from when the
+                        proving began to when it was complete.
+                        <br />
+                        (hours : minutes : seconds)
+                      </MetricInfo>
+                    </MetricLabel>
+                    <MetricValue
+                      title={
+                        prover_duration
+                          ? intervalToReadable(prover_duration as string)
+                          : ""
+                      }
                     >
-                      {team?.team_name}
-                    </Link>
-                  )}
+                      {(prover_duration as string) || <Null />}
+                    </MetricValue>
+                  </MetricBox>
+                  <MetricBox
+                    className={cn(
+                      "col-span-2 col-start-3 row-span-1 row-start-2",
+                      "sm:col-span-1 sm:col-start-2 sm:row-span-1 sm:row-start-2",
+                      "md:col-span-1 md:col-start-3 md:row-span-1 md:row-start-1"
+                    )}
+                  >
+                    <MetricLabel>
+                      Latency
+                      <MetricInfo>
+                        Time delay from when a block is published, to when proof
+                        has been posted
+                        <br />
+                        (seconds)
+                      </MetricInfo>
+                    </MetricLabel>
+                    <MetricValue>
+                      {proof_latency ? (
+                        prettyMilliseconds(proof_latency)
+                      ) : (
+                        <Null />
+                      )}
+                    </MetricValue>
+                  </MetricBox>
+                  <MetricBox
+                    className={cn(
+                      "col-span-2 col-start-1 row-span-1 row-start-3",
+                      "sm:col-span-1 sm:col-start-3 sm:row-span-1 sm:row-start-2",
+                      "md:col-span-1 md:col-start-4 md:row-span-1 md:row-start-1"
+                    )}
+                  >
+                    <MetricLabel>
+                      <span className="normal-case">{team?.team_name}</span> zk
+                      <span className="uppercase">VM</span> cycles
+                      <MetricInfo>
+                        The number of cycles used by the prover to generate the
+                        proof.
+                      </MetricInfo>
+                    </MetricLabel>
+                    <MetricValue
+                      title={proving_cycles ? formatNumber(proving_cycles) : ""}
+                    >
+                      {proving_cycles ? (
+                        formatNumber(proving_cycles, {
+                          notation: "compact",
+                          compactDisplay: "short",
+                          maximumSignificantDigits: 4,
+                        })
+                      ) : (
+                        <Null />
+                      )}
+                    </MetricValue>
+                  </MetricBox>
+                  <MetricBox
+                    className={cn(
+                      "col-span-2 col-start-3 row-span-1 row-start-3",
+                      "sm:col-span-1 sm:col-start-4 sm:row-span-1 sm:row-start-2",
+                      "md:col-span-1 md:col-start-5 md:row-span-1 md:row-start-1",
+                      "sm:max-md:text-end"
+                    )}
+                  >
+                    <MetricLabel className="sm:max-md:justify-end">
+                      Proving cost
+                      <MetricInfo>
+                        The cost of generating this proof.
+                        <br />
+                        (USD)
+                      </MetricInfo>
+                    </MetricLabel>
+                    <MetricValue>
+                      {proving_cost ? (
+                        formatNumber(proving_cost, {
+                          style: "currency",
+                          currency: "USD",
+                        })
+                      ) : (
+                        <Null />
+                      )}
+                    </MetricValue>
+                  </MetricBox>
                 </div>
-                <Button
-                  variant="outline"
-                  className={cn(
-                    "ms-auto h-8 w-8 min-w-fit gap-2 self-center text-2xl text-primary",
-                    "col-span-1 col-start-4 row-span-1 row-start-1",
-                    "sm:col-span-2 sm:col-start-3 sm:row-span-1 sm:row-start-1",
-                    "md:col-span-1 md:col-start-6 md:row-span-1 md:row-start-1"
-                  )}
-                >
-                  <ArrowDown />
-                  <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
-                    Download proof
-                  </span>
-                </Button>
-                <MetricBox
-                  className={cn(
-                    "col-span-2 col-start-1 row-span-1 row-start-2",
-                    "sm:col-span-1 sm:col-start-1 sm:row-span-1 sm:row-start-2",
-                    "md:col-span-1 md:col-start-2 md:row-span-1 md:row-start-1"
-                  )}
-                >
-                  <MetricLabel>
-                    Time to proof
-                    <MetricInfo>
-                      The time it took to generate this proof, from when the
-                      proving began to when it was complete.
-                      <br />
-                      (hours : minutes : seconds)
-                    </MetricInfo>
-                  </MetricLabel>
-                  <MetricValue
-                    title={
-                      prover_duration
-                        ? intervalToReadable(prover_duration as string)
-                        : ""
-                    }
-                  >
-                    {(prover_duration as string) || <Null />}
-                  </MetricValue>
-                </MetricBox>
-                <MetricBox
-                  className={cn(
-                    "col-span-2 col-start-3 row-span-1 row-start-2",
-                    "sm:col-span-1 sm:col-start-2 sm:row-span-1 sm:row-start-2",
-                    "md:col-span-1 md:col-start-3 md:row-span-1 md:row-start-1"
-                  )}
-                >
-                  <MetricLabel>
-                    Latency
-                    <MetricInfo>
-                      Time delay from when a block is published, to when proof
-                      has been posted
-                      <br />
-                      (seconds)
-                    </MetricInfo>
-                  </MetricLabel>
-                  <MetricValue>
-                    {proof_latency ? (
-                      prettyMilliseconds(proof_latency)
-                    ) : (
-                      <Null />
-                    )}
-                  </MetricValue>
-                </MetricBox>
-                <MetricBox
-                  className={cn(
-                    "col-span-2 col-start-1 row-span-1 row-start-3",
-                    "sm:col-span-1 sm:col-start-3 sm:row-span-1 sm:row-start-2",
-                    "md:col-span-1 md:col-start-4 md:row-span-1 md:row-start-1"
-                  )}
-                >
-                  <MetricLabel>
-                    <span className="normal-case">{team?.team_name}</span> zk
-                    <span className="uppercase">VM</span> cycles
-                    <MetricInfo>
-                      The number of cycles used by the prover to generate the
-                      proof.
-                    </MetricInfo>
-                  </MetricLabel>
-                  <MetricValue
-                    title={proving_cycles ? formatNumber(proving_cycles) : ""}
-                  >
-                    {proving_cycles ? (
-                      formatNumber(proving_cycles, {
-                        notation: "compact",
-                        compactDisplay: "short",
-                        maximumSignificantDigits: 4,
-                      })
-                    ) : (
-                      <Null />
-                    )}
-                  </MetricValue>
-                </MetricBox>
-                <MetricBox
-                  className={cn(
-                    "col-span-2 col-start-3 row-span-1 row-start-3",
-                    "sm:col-span-1 sm:col-start-4 sm:row-span-1 sm:row-start-2",
-                    "md:col-span-1 md:col-start-5 md:row-span-1 md:row-start-1",
-                    "sm:max-md:text-end"
-                  )}
-                >
-                  <MetricLabel className="sm:max-md:justify-end">
-                    Proving cost
-                    <MetricInfo>
-                      The cost of generating this proof.
-                      <br />
-                      (USD)
-                    </MetricInfo>
-                  </MetricLabel>
-                  <MetricValue>
-                    {proving_cost ? (
-                      formatNumber(proving_cost, {
-                        style: "currency",
-                        currency: "USD",
-                      })
-                    ) : (
-                      <Null />
-                    )}
-                  </MetricValue>
-                </MetricBox>
-              </div>
-            )
-          }
-        )}
+              )
+            }
+          )}
       </section>
     </div>
   )

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -14,11 +14,14 @@ export const ProofStatusInfo = () => (
   <>
     <TooltipContentHeader>proof status</TooltipContentHeader>
     <div className="items-top grid grid-cols-[auto,1fr] gap-4">
-      <Box className="self-center text-2xl text-primary" />
+      <Box strokeWidth="1" className="self-center text-2xl text-primary" />
       Number of completed proofs that have been published for this block
       <BoxDashed className="self-center text-2xl text-primary" />
       Number of provers currently generating proofs for this block
-      <Box className="self-center text-2xl text-body-secondary" />
+      <Box
+        strokeWidth="1"
+        className="self-center text-2xl text-body-secondary"
+      />
       Number of provers who have indicated intent to prove this block
     </div>
     <p className="text-body-secondary">
@@ -44,7 +47,7 @@ const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
         <MetricInfo
           trigger={
             <div className="flex flex-nowrap items-center gap-1">
-              <Box className="text-primary" />
+              <Box strokeWidth="1" className="text-primary" />
               <span className="block">{completedProofs.length}</span>
             </div>
           }
@@ -58,7 +61,7 @@ const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
         <MetricInfo
           trigger={
             <div className="flex flex-nowrap items-center gap-1">
-              <BoxDashed className="text-primary" />
+              <BoxDashed strokeWidth="1" className="text-primary" />
               <span className="block">{provingProofs.length}</span>
             </div>
           }
@@ -72,7 +75,7 @@ const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
         <MetricInfo
           trigger={
             <div className="flex flex-nowrap items-center gap-1">
-              <Box className="text-body-secondary" />
+              <Box strokeWidth="1" className="text-body-secondary" />
               <span className="block">{queuedProofs.length}</span>
             </div>
           }

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -19,16 +19,33 @@ import { cn, isMobile } from "@/lib/utils"
 
 import { useDisclosure } from "@/hooks/useDisclosure"
 
+/**
+ * @typedef TooltipProps
+ * @property {string} [className] - Additional class names to style the tooltip.
+ * @property {() => void} [onBeforeOpen] - Callback function to be called before the tooltip opens.
+ * @property {HTMLElement | null} [container] - The container element for the tooltip.
+ *
+ * @property {ReactNode} [trigger] - The element that triggers the tooltip. Either `trigger` or `content` must be provided, but not both.
+ * @property {ReactNode} [content] - The content of the tooltip. Either `content` or `trigger` must be provided, but not both.
+ * @property {ReactNode} [children] - If trigger provided, children used as content of tooltip. If content provided, children used as the element that triggers the tooltip.
+ *
+ * Note: Either `trigger` OR `content` is required. `children` will be used for the other.
+ */
 export type TooltipProps = ComponentProps<typeof UIPopover> & {
-  trigger: ReactNode
   children?: ReactNode
   className?: string
   onBeforeOpen?: () => void
   container?: HTMLElement | null
-}
+} & (
+    | {
+        trigger: ReactNode
+      }
+    | {
+        content: ReactNode
+      }
+  )
 
 const Tooltip = ({
-  trigger,
   children,
   onBeforeOpen,
   container,
@@ -36,6 +53,10 @@ const Tooltip = ({
   ...props
 }: TooltipProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const trigger = "trigger" in props ? props.trigger : children
+  const content = "content" in props ? props.content : children
+
   // Close the popover when the user scrolls.
   // This is useful for mobile devices where the popover is open by clicking the
   // trigger, not hovering.
@@ -68,11 +89,7 @@ const Tooltip = ({
   }
 
   const handleOpenChange = (open: boolean) => {
-    if (open) {
-      handleOpen()
-    } else {
-      onClose()
-    }
+    ;(open ? handleOpen : onClose)()
   }
 
   // Use Popover on mobile devices since the user can't hover
@@ -99,7 +116,7 @@ const Tooltip = ({
             className={cn("max-w-80 px-5 text-sm", className)}
             data-testid="tooltip-popover"
           >
-            {children}
+            {content}
           </Content>
         </Portal>
       </Component>

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -120,3 +120,39 @@ export const getProofCheapestProvingCost = (proofs: Proof[]): Proof | null => {
     return a.proving_cost < b.proving_cost ? a : b
   }, completedProofs[0])
 }
+
+// Primary sort by proof_status: proved, proving, then queued
+// Secondary sorts (lower/earlier first)
+// Within `proved` use `proof_latency`
+// Within `proving` use `proving_timestamp`
+// Within `queued` use `queued_timestamp`
+export const sortProofsStatusAndTimes = (a: Proof, b: Proof) => {
+  if (a.proof_status === "proved" && b.proof_status !== "proved") return -1
+  if (a.proof_status !== "proved" && b.proof_status === "proved") return 1
+  if (a.proof_status === "proving" && b.proof_status !== "proving") return -1
+  if (a.proof_status !== "proving" && b.proof_status === "proving") return 1
+  if (a.proof_status === "queued" && b.proof_status !== "queued") return -1
+  if (a.proof_status !== "queued" && b.proof_status === "queued") return 1
+  if (a.proof_status === "proved") {
+    if (!a.proof_latency) return 1
+    if (!b.proof_latency) return -1
+    return a.proof_latency - b.proof_latency
+  }
+  if (a.proof_status === "proving") {
+    if (!a.proving_timestamp) return 1
+    if (!b.proving_timestamp) return -1
+    return (
+      new Date(a.proving_timestamp).getTime() -
+      new Date(b.proving_timestamp).getTime()
+    )
+  }
+  if (a.proof_status === "queued") {
+    if (!a.queued_timestamp) return 1
+    if (!b.queued_timestamp) return -1
+    return (
+      new Date(a.queued_timestamp).getTime() -
+      new Date(b.queued_timestamp).getTime()
+    )
+  }
+  return 0
+}


### PR DESCRIPTION
## Description
- Updates the proofs table within the block/[block] page
- Adds tooltips
- Updates download button to act as proof status indicator while not yet in `proved` state

## Preview link
https://deploy-preview-122--ethproofs.netlify.app/block/21272228

## Screenshot
<img width="1471" alt="image" src="https://github.com/user-attachments/assets/d7aa5627-5582-44af-bbc3-ae962d7ea25a">
