### PR TITLE
feat: Add StatusIcon, redesign styling for statuses

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -313,7 +313,7 @@ export default async function BlockDetailsPage({
     <div className="space-y-20">
       <HeroSection>
         <HeroTitle>
-          <Box strokeWidth="1" className="text-6xl text-primary shrink-0" />
+          <Box strokeWidth="1" className="shrink-0 text-6xl text-primary" />
           <h1 className="font-mono">
             <p className="text-sm font-normal md:text-lg">Block Height</p>
             <p className="text-3xl font-semibold tracking-wide">

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -6,6 +6,7 @@ import prettyMilliseconds from "pretty-ms"
 import type { Metric } from "@/lib/types"
 
 import CopyButton from "@/components/CopyButton"
+import DownloadButton from "@/components/DownloadButton"
 import Null from "@/components/Null"
 import ProofStatus, { ProofStatusInfo } from "@/components/ProofStatus"
 import StatusIcon from "@/components/StatusIcon"
@@ -96,6 +97,11 @@ export default async function BlockDetailsPage({
   if (!block || error || !teams) notFound()
 
   const { timestamp, block_number, gas_used, proofs, hash } = block
+
+  const proofsWithTeams = proofs.map((proof) => {
+    const team = teams.find((t) => t.user_id === proof.user_id)
+    return { ...proof, team }
+  })
 
   // TODO: Add proper descriptions
 
@@ -412,297 +418,224 @@ export default async function BlockDetailsPage({
           <ProofCircle /> Proofs
         </h2>
 
-        {proofs
-          .sort(sortProofsStatusAndTimes)
-          .map(
-            ({
-              proof_id,
-              proof_latency,
-              proof_status,
-              proved_timestamp,
-              proving_cost,
-              proving_cycles,
-              user_id,
-            }) => {
-              const team = teams.find((t) => t.user_id === user_id)
-              const isComplete = proof_status === "proved" && !!proved_timestamp
-              const timeToProof = proved_timestamp
-                ? Math.max(
-                    new Date(proved_timestamp).getTime() -
-                      new Date(block.timestamp).getTime(),
-                    0
-                  )
-                : 0
-              return (
-                <div
-                  className={cn(
-                    "grid grid-flow-dense grid-cols-4 grid-rows-3",
-                    "sm:grid-rows-2",
-                    "md:grid-cols-6-auto md:grid-rows-1"
+        {proofsWithTeams.sort(sortProofsStatusAndTimes).map((proof) => {
+          const {
+            proof_id,
+            proof_latency,
+            proof_status,
+            proved_timestamp,
+            proving_cost,
+            proving_cycles,
+            team,
+          } = proof
+          const isComplete = proof_status === "proved" && !!proved_timestamp
+          const timeToProof = proved_timestamp
+            ? Math.max(
+                new Date(proved_timestamp).getTime() -
+                  new Date(block.timestamp).getTime(),
+                0
+              )
+            : 0
+          return (
+            <div
+              className={cn(
+                "grid grid-flow-dense grid-cols-4 grid-rows-3",
+                "sm:grid-rows-2",
+                "md:grid-cols-6-auto md:grid-rows-1"
+              )}
+              key={proof_id}
+            >
+              <div
+                className={cn(
+                  "relative flex h-full items-center",
+                  "col-span-3 col-start-1 row-span-1 row-start-1",
+                  "sm:col-span-2 sm:col-start-1 sm:row-span-1 sm:row-start-1",
+                  "md:col-span-1 md:col-start-1 md:row-span-1 md:row-start-1"
+                )}
+              >
+                {team?.team_name && (
+                  <Link
+                    href={"/prover/" + team?.team_id}
+                    className="text-2xl hover:text-primary-light hover:underline"
+                  >
+                    {team.team_name}
+                  </Link>
+                )}
+              </div>
+              <div
+                className={cn(
+                  "ms-auto self-center",
+                  "col-span-1 col-start-4 row-span-1 row-start-1",
+                  "sm:col-span-2 sm:col-start-3 sm:row-span-1 sm:row-start-1",
+                  "md:col-span-1 md:col-start-6 md:row-span-1 md:row-start-1"
+                )}
+              >
+                <DownloadButton proof={proof} />
+              </div>{" "}
+              <MetricBox
+                className={cn(
+                  "col-span-2 col-start-1 row-span-1 row-start-2",
+                  "sm:col-span-1 sm:col-start-1 sm:row-span-1 sm:row-start-2",
+                  "md:col-span-1 md:col-start-2 md:row-span-1 md:row-start-1"
+                )}
+              >
+                <MetricLabel>
+                  time to proof
+                  <MetricInfo>
+                    <TooltipContentHeader>time to proof</TooltipContentHeader>
+                    <div className="rounded border bg-background px-3 py-2">
+                      <span className="italic">proof submission time</span> -{" "}
+                      <span className="font-mono text-primary-light">
+                        timestamp
+                      </span>
+                    </div>
+                    <p>
+                      <span className="italic">proof submission time</span> is
+                      the timestamp logged by {SITE_NAME} when a completed proof
+                      has been submitted
+                    </p>
+                    <p>
+                      <span className="font-mono text-primary-light">
+                        timestamp
+                      </span>{" "}
+                      value from execution block header
+                    </p>
+                    <p className="text-body-secondary">
+                      Total time delay between execution block timestamp and
+                      completion and publishing of proof
+                    </p>
+                  </MetricInfo>
+                </MetricLabel>
+                <MetricValue className="font-normal">
+                  {isComplete && timeToProof > 0 ? (
+                    prettyMilliseconds(timeToProof)
+                  ) : (
+                    <Null />
                   )}
-                  key={proof_id}
-                >
-                  <div
-                    className={cn(
-                      "relative flex h-full items-center",
-                      "col-span-3 col-start-1 row-span-1 row-start-1",
-                      "sm:col-span-2 sm:col-start-1 sm:row-span-1 sm:row-start-1",
-                      "md:col-span-1 md:col-start-1 md:row-span-1 md:row-start-1"
-                    )}
-                  >
-                    {team?.team_name && (
-                      <Link
-                        href={"/prover/" + team?.team_id}
-                        className="text-2xl hover:text-primary-light hover:underline"
-                      >
-                        {team.team_name}
-                      </Link>
-                    )}
-                  </div>
-                  <div
-                    className={cn(
-                      "ms-auto self-center",
-                      "col-span-1 col-start-4 row-span-1 row-start-1",
-                      "sm:col-span-2 sm:col-start-3 sm:row-span-1 sm:row-start-1",
-                      "md:col-span-1 md:col-start-6 md:row-span-1 md:row-start-1"
-                    )}
-                  >
-                    {proof_status === "proved" && (
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "aspect-square h-8 w-auto gap-2 self-center text-2xl text-primary",
-                          "disabled:bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40"
-                        )}
-                        size="icon"
-                        isSecondary={!isComplete}
-                        disabled={!isComplete}
-                      >
-                        <ArrowDown />
-                        <span className="hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block">
-                          Download proof
-                        </span>
-                      </Button>
-                    )}
-                    {proof_status === "proving" && (
-                      <Tooltip
-                        content={`${team?.team_name ? team.team_name : "Team"} currently generating proof for this block`}
-                      >
-                        <div
-                          className={cn(
-                            "inline-flex items-center justify-center gap-4 rounded-full border border-solid border-current text-primary [&>svg]:shrink-0",
-                            "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
-                            "bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40",
-                            "flex items-center gap-2"
-                          )}
-                        >
-                          <StatusIcon
-                            status="proving"
-                            className="animate-pulse"
-                          />
-                          <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
-                            Proving
-                          </span>
-                        </div>
-                      </Tooltip>
-                    )}
-                    {proof_status === "queued" && (
-                      <Tooltip
-                        content={`${team?.team_name ? team.team_name : "Team"} has indicated intent to prove this block`}
-                      >
-                        <div
-                          className={cn(
-                            "inline-flex items-center justify-center gap-4 rounded-full border border-solid border-current text-primary [&>svg]:shrink-0",
-                            "aspect-square h-8 w-auto min-w-fit gap-2 self-center text-2xl text-primary",
-                            "bg-body-secondary/10 sm:max-md:w-40 lg:aspect-auto lg:w-40",
-                            "flex items-center gap-2"
-                          )}
-                        >
-                          <StatusIcon status="queued" />
-                          <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
-                            Queued
-                          </span>
-                        </div>
-                      </Tooltip>
-                    )}
-                  </div>
-                  <MetricBox
-                    className={cn(
-                      "col-span-2 col-start-1 row-span-1 row-start-2",
-                      "sm:col-span-1 sm:col-start-1 sm:row-span-1 sm:row-start-2",
-                      "md:col-span-1 md:col-start-2 md:row-span-1 md:row-start-1"
-                    )}
-                  >
-                    <MetricLabel>
-                      time to proof
-                      <MetricInfo>
-                        <TooltipContentHeader>
-                          time to proof
-                        </TooltipContentHeader>
-                        <div className="rounded border bg-background px-3 py-2">
-                          <span className="italic">proof submission time</span>{" "}
-                          -{" "}
-                          <span className="font-mono text-primary-light">
-                            timestamp
-                          </span>
-                        </div>
-                        <p>
-                          <span className="italic">proof submission time</span>{" "}
-                          is the timestamp logged by {SITE_NAME} when a
-                          completed proof has been submitted
-                        </p>
-                        <p>
-                          <span className="font-mono text-primary-light">
-                            timestamp
-                          </span>{" "}
-                          value from execution block header
-                        </p>
-                        <p className="text-body-secondary">
-                          Total time delay between execution block timestamp and
-                          completion and publishing of proof
-                        </p>
-                      </MetricInfo>
-                    </MetricLabel>
-                    <MetricValue className="font-normal">
-                      {isComplete && timeToProof > 0 ? (
-                        prettyMilliseconds(timeToProof)
-                      ) : (
-                        <Null />
-                      )}
-                    </MetricValue>
-                  </MetricBox>
-                  <MetricBox
-                    className={cn(
-                      "col-span-2 col-start-3 row-span-1 row-start-2",
-                      "sm:col-span-1 sm:col-start-2 sm:row-span-1 sm:row-start-2",
-                      "md:col-span-1 md:col-start-3 md:row-span-1 md:row-start-1"
-                    )}
-                  >
-                    <MetricLabel>
-                      proving time
-                      <MetricInfo>
-                        <TooltipContentHeader>
-                          proving time
-                        </TooltipContentHeader>
-                        <div className="rounded border bg-background px-3 py-2">
-                          <span className="italic">proof latency</span>
-                        </div>
-                        <p>
-                          <span className="italic">proof latency</span> is
-                          duration of the proof generation process, self
-                          reported by proving teams
-                        </p>
-                        <p className="text-body-secondary">
-                          Time spent generating proof of execution
-                        </p>
-                      </MetricInfo>
-                    </MetricLabel>
-                    <MetricValue className="font-normal">
-                      {isComplete && proof_latency ? (
-                        prettyMilliseconds(proof_latency)
-                      ) : (
-                        <Null />
-                      )}
-                    </MetricValue>
-                  </MetricBox>
-                  <MetricBox
-                    className={cn(
-                      "col-span-2 col-start-1 row-span-1 row-start-3",
-                      "sm:col-span-1 sm:col-start-3 sm:row-span-1 sm:row-start-2",
-                      "md:col-span-1 md:col-start-4 md:row-span-1 md:row-start-1"
-                    )}
-                  >
-                    <MetricLabel>
+                </MetricValue>
+              </MetricBox>
+              <MetricBox
+                className={cn(
+                  "col-span-2 col-start-3 row-span-1 row-start-2",
+                  "sm:col-span-1 sm:col-start-2 sm:row-span-1 sm:row-start-2",
+                  "md:col-span-1 md:col-start-3 md:row-span-1 md:row-start-1"
+                )}
+              >
+                <MetricLabel>
+                  proving time
+                  <MetricInfo>
+                    <TooltipContentHeader>proving time</TooltipContentHeader>
+                    <div className="rounded border bg-background px-3 py-2">
+                      <span className="italic">proof latency</span>
+                    </div>
+                    <p>
+                      <span className="italic">proof latency</span> is duration
+                      of the proof generation process, self reported by proving
+                      teams
+                    </p>
+                    <p className="text-body-secondary">
+                      Time spent generating proof of execution
+                    </p>
+                  </MetricInfo>
+                </MetricLabel>
+                <MetricValue className="font-normal">
+                  {isComplete && proof_latency ? (
+                    prettyMilliseconds(proof_latency)
+                  ) : (
+                    <Null />
+                  )}
+                </MetricValue>
+              </MetricBox>
+              <MetricBox
+                className={cn(
+                  "col-span-2 col-start-1 row-span-1 row-start-3",
+                  "sm:col-span-1 sm:col-start-3 sm:row-span-1 sm:row-start-2",
+                  "md:col-span-1 md:col-start-4 md:row-span-1 md:row-start-1"
+                )}
+              >
+                <MetricLabel>
+                  <span className="normal-case">{team?.team_name}</span> zk
+                  <span className="uppercase">VM</span> cycles
+                  <MetricInfo>
+                    <TooltipContentHeader>
                       <span className="normal-case">{team?.team_name}</span> zk
                       <span className="uppercase">VM</span> cycles
-                      <MetricInfo>
-                        <TooltipContentHeader>
-                          <span className="normal-case">{team?.team_name}</span>{" "}
-                          zk<span className="uppercase">VM</span> cycles
-                        </TooltipContentHeader>
-                        <div className="rounded border bg-background px-3 py-2">
-                          <span className="italic">proving cycles</span>
-                        </div>
-                        <p>
-                          <span className="italic">proving cycles</span> is
-                          self-reported by{" "}
-                          {team?.team_name
-                            ? team.team_name
-                            : "the proving team"}
-                        </p>
-                        <p className="text-body-secondary">
-                          The number of cycles used by{" "}
-                          {team?.team_name
-                            ? team.team_name
-                            : "the proving team"}{" "}
-                          to generate the proof.
-                        </p>
-                        <p className="text-body-secondary">
-                          This number will vary depending on hardware and zkVMs
-                          being used by different provers and should not be
-                          directly compared to other provers.
-                        </p>
-                      </MetricInfo>
-                    </MetricLabel>
-                    <MetricValue
-                      className="font-normal"
-                      title={proving_cycles ? formatNumber(proving_cycles) : ""}
-                    >
-                      {isComplete && proving_cycles ? (
-                        formatNumber(proving_cycles, {
-                          notation: "compact",
-                          compactDisplay: "short",
-                          maximumSignificantDigits: 4,
-                        })
-                      ) : (
-                        <Null />
-                      )}
-                    </MetricValue>
-                  </MetricBox>
-                  <MetricBox
-                    className={cn(
-                      "col-span-2 col-start-3 row-span-1 row-start-3",
-                      "sm:col-span-1 sm:col-start-4 sm:row-span-1 sm:row-start-2",
-                      "md:col-span-1 md:col-start-5 md:row-span-1 md:row-start-1",
-                      "sm:max-md:text-end"
-                    )}
-                  >
-                    <MetricLabel className="sm:max-md:justify-end">
-                      proving costs
-                      <MetricInfo>
-                        <TooltipContentHeader>
-                          proving costs
-                        </TooltipContentHeader>
-                        <div className="rounded border bg-background px-3 py-2">
-                          <span className="italic">proving costs</span>
-                        </div>
-                        <p>
-                          <span className="italic">proving costs</span> are in
-                          USD, self-reported by{" "}
-                          {team?.team_name ? team.team_name : "proving team"}
-                        </p>
-                        <p className="text-body-secondary">
-                          Proving costs are in USD, and represent the
-                          self-reported expenditures included in proving this
-                          block
-                        </p>
-                      </MetricInfo>
-                    </MetricLabel>
-                    <MetricValue className="font-normal">
-                      {isComplete && proving_cost ? (
-                        formatNumber(proving_cost, {
-                          style: "currency",
-                          currency: "USD",
-                        })
-                      ) : (
-                        <Null />
-                      )}
-                    </MetricValue>
-                  </MetricBox>
-                </div>
-              )
-            }
-          )}
+                    </TooltipContentHeader>
+                    <div className="rounded border bg-background px-3 py-2">
+                      <span className="italic">proving cycles</span>
+                    </div>
+                    <p>
+                      <span className="italic">proving cycles</span> is
+                      self-reported by{" "}
+                      {team?.team_name ? team.team_name : "the proving team"}
+                    </p>
+                    <p className="text-body-secondary">
+                      The number of cycles used by{" "}
+                      {team?.team_name ? team.team_name : "the proving team"} to
+                      generate the proof.
+                    </p>
+                    <p className="text-body-secondary">
+                      This number will vary depending on hardware and zkVMs
+                      being used by different provers and should not be directly
+                      compared to other provers.
+                    </p>
+                  </MetricInfo>
+                </MetricLabel>
+                <MetricValue
+                  className="font-normal"
+                  title={proving_cycles ? formatNumber(proving_cycles) : ""}
+                >
+                  {isComplete && proving_cycles ? (
+                    formatNumber(proving_cycles, {
+                      notation: "compact",
+                      compactDisplay: "short",
+                      maximumSignificantDigits: 4,
+                    })
+                  ) : (
+                    <Null />
+                  )}
+                </MetricValue>
+              </MetricBox>
+              <MetricBox
+                className={cn(
+                  "col-span-2 col-start-3 row-span-1 row-start-3",
+                  "sm:col-span-1 sm:col-start-4 sm:row-span-1 sm:row-start-2",
+                  "md:col-span-1 md:col-start-5 md:row-span-1 md:row-start-1",
+                  "sm:max-md:text-end"
+                )}
+              >
+                <MetricLabel className="sm:max-md:justify-end">
+                  proving costs
+                  <MetricInfo>
+                    <TooltipContentHeader>proving costs</TooltipContentHeader>
+                    <div className="rounded border bg-background px-3 py-2">
+                      <span className="italic">proving costs</span>
+                    </div>
+                    <p>
+                      <span className="italic">proving costs</span> are in USD,
+                      self-reported by{" "}
+                      {team?.team_name ? team.team_name : "proving team"}
+                    </p>
+                    <p className="text-body-secondary">
+                      Proving costs are in USD, and represent the self-reported
+                      expenditures included in proving this block
+                    </p>
+                  </MetricInfo>
+                </MetricLabel>
+                <MetricValue className="font-normal">
+                  {isComplete && proving_cost ? (
+                    formatNumber(proving_cost, {
+                      style: "currency",
+                      currency: "USD",
+                    })
+                  ) : (
+                    <Null />
+                  )}
+                </MetricValue>
+              </MetricBox>
+            </div>
+          )
+        })}
       </section>
     </div>
   )

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -496,7 +496,10 @@ export default async function BlockDetailsPage({
                             "flex items-center gap-2"
                           )}
                         >
-                          <StatusIcon status="proving" />
+                          <StatusIcon
+                            status="proving"
+                            className="animate-pulse"
+                          />
                           <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
                             Proving
                           </span>

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -8,11 +8,11 @@ import type { Metric } from "@/lib/types"
 import CopyButton from "@/components/CopyButton"
 import Null from "@/components/Null"
 import ProofStatus, { ProofStatusInfo } from "@/components/ProofStatus"
+import StatusIcon from "@/components/StatusIcon"
 import { HidePunctuation } from "@/components/StylePunctuation"
 import ArrowDown from "@/components/svgs/arrow-down.svg"
 import BookOpen from "@/components/svgs/book-open.svg"
 import Box from "@/components/svgs/box.svg"
-import BoxDashed from "@/components/svgs/box-dashed.svg"
 import Clock from "@/components/svgs/clock.svg"
 import Cpu from "@/components/svgs/cpu.svg"
 import DollarSign from "@/components/svgs/dollar-sign.svg"
@@ -45,7 +45,6 @@ import { SITE_NAME } from "@/lib/constants"
 
 import { timestampToEpoch, timestampToSlot } from "@/lib/beaconchain"
 import { getBlockValueType } from "@/lib/blocks"
-import { intervalToReadable } from "@/lib/date"
 import { getMetadata } from "@/lib/metadata"
 import { formatNumber } from "@/lib/number"
 import {
@@ -497,7 +496,7 @@ export default async function BlockDetailsPage({
                             "flex items-center gap-2"
                           )}
                         >
-                          <BoxDashed className="text-primary-dark" />
+                          <StatusIcon status="proving" />
                           <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
                             Proving
                           </span>
@@ -516,10 +515,7 @@ export default async function BlockDetailsPage({
                             "flex items-center gap-2"
                           )}
                         >
-                          <Box
-                            strokeWidth="1"
-                            className="text-body-secondary"
-                          />
+                          <StatusIcon status="queued" />
                           <span className="hidden text-nowrap text-xs font-bold text-body-secondary sm:block md:hidden lg:block">
                             Queued
                           </span>

--- a/components/DownloadButton.tsx
+++ b/components/DownloadButton.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import type { Proof, Team } from "@/lib/types"
+
+import ArrowDown from "@/components/svgs/arrow-down.svg"
+
+import { cn } from "@/lib/utils"
+
+import { Button } from "./ui/button"
+import StatusIcon from "./StatusIcon"
+import Tooltip from "./Tooltip"
+
+import { downloadProof } from "@/lib/proofs"
+
+type DownloadButtonProps = {
+  proof: Proof & { team?: Team }
+  className?: string
+}
+
+const DownloadButton = ({ className, proof }: DownloadButtonProps) => {
+  const { proof_status, proof: binary, team } = proof
+  const teamName = team?.team_name ? team.team_name : "Team"
+
+  const sizingClassName =
+    "h-8 gap-2 self-center text-2xl sm:max-md:w-40 lg:w-40"
+  const labelClassName =
+    "hidden text-nowrap text-xs font-bold sm:block md:hidden lg:block"
+  const fakeButtonClassName =
+    "bg-body-secondary/10 hover:bg-body-secondary/10 cursor-auto"
+
+  if (proof_status === "proved")
+    return (
+      <Button
+        variant="outline"
+        className={cn(sizingClassName, className)}
+        size="icon"
+        disabled={!binary}
+        onClick={() => downloadProof(proof)}
+      >
+        <ArrowDown />
+        <span className={labelClassName}>Download proof</span>
+      </Button>
+    )
+
+  if (proof_status === "proving")
+    return (
+      <Tooltip
+        content={`${teamName} currently generating proof for this block`}
+      >
+        <Button size="icon" variant="outline" asChild>
+          <div className={cn(sizingClassName, fakeButtonClassName, className)}>
+            <StatusIcon status="proving" className="animate-pulse" />
+            <span className={cn(labelClassName, "text-body-secondary")}>
+              Proving
+            </span>
+          </div>
+        </Button>
+      </Tooltip>
+    )
+
+  if (proof_status === "queued")
+    return (
+      <Tooltip content={`${teamName} has indicated intent to prove this block`}>
+        <Button size="icon" variant="outline" asChild>
+          <div className={cn(sizingClassName, fakeButtonClassName, className)}>
+            <StatusIcon status="queued" />
+            <span className={cn(labelClassName, "text-body-secondary")}>
+              Queued
+            </span>
+          </div>
+        </Button>
+      </Tooltip>
+    )
+}
+
+export default DownloadButton

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -41,7 +41,7 @@ const ProofStatus = ({
 
   return (
     <figure
-      className={cn("flex items-center gap-3 font-mono", className)}
+      className={cn("flex items-center gap-4 font-mono", className)}
       {...props}
     >
       {(completedProofs.length > 0 || !hideEmpty) && (

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -27,60 +27,72 @@ export const ProofStatusInfo = () => (
 
 type ProofStatusProps = React.HTMLAttributes<HTMLDivElement> & {
   proofs: Proof[]
+  hideEmpty: boolean
 }
-const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
+const ProofStatus = ({
+  proofs,
+  className,
+  hideEmpty,
+  ...props
+}: ProofStatusProps) => {
   const completedProofs = proofs.filter(isCompleted)
   const provingProofs = proofs.filter((p) => p.proof_status === "proving")
   const queuedProofs = proofs.filter((p) => p.proof_status === "queued")
 
   return (
-    <div
+    <figure
       className={cn("flex items-center gap-3 font-mono", className)}
       {...props}
     >
-      <div className="flex items-center gap-1">
-        <MetricInfo
-          trigger={
-            <div className="flex flex-nowrap items-center gap-1">
-              <StatusIcon status="proved" />
-              <span className="block">{completedProofs.length}</span>
-            </div>
-          }
-        >
-          <span className="!font-body text-body">
-            Number of completed proofs that have been published for this block
-          </span>
-        </MetricInfo>
-      </div>
-      <div className="flex items-center gap-1">
-        <MetricInfo
-          trigger={
-            <div className="flex flex-nowrap items-center gap-1">
-              <StatusIcon status="proving" />
-              <span className="block">{provingProofs.length}</span>
-            </div>
-          }
-        >
-          <span className="!font-body text-body">
-            Number of provers currently generating proofs for this block
-          </span>
-        </MetricInfo>
-      </div>
-      <div className="flex items-center gap-1">
-        <MetricInfo
-          trigger={
-            <div className="flex flex-nowrap items-center gap-1">
-              <StatusIcon status="queued" />
-              <span className="block">{queuedProofs.length}</span>
-            </div>
-          }
-        >
-          <span className="!font-body text-body">
-            Number of provers who have indicated intent to prove this block
-          </span>
-        </MetricInfo>
-      </div>
-    </div>
+      {(completedProofs.length > 0 || !hideEmpty) && (
+        <div className="flex items-center gap-1">
+          <MetricInfo
+            trigger={
+              <div className="flex flex-nowrap items-center gap-1">
+                <StatusIcon status="proved" />
+                <span className="block">{completedProofs.length}</span>
+              </div>
+            }
+          >
+            <span className="!font-body text-body">
+              Number of completed proofs that have been published for this block
+            </span>
+          </MetricInfo>
+        </div>
+      )}
+      {(provingProofs.length > 0 || !hideEmpty) && (
+        <div className="flex items-center gap-1">
+          <MetricInfo
+            trigger={
+              <div className="flex flex-nowrap items-center gap-1">
+                <StatusIcon status="proving" />
+                <span className="block">{provingProofs.length}</span>
+              </div>
+            }
+          >
+            <span className="!font-body text-body">
+              Number of provers currently generating proofs for this block
+            </span>
+          </MetricInfo>
+        </div>
+      )}
+      {(queuedProofs.length > 0 || !hideEmpty) && (
+        <div className="flex items-center gap-1">
+          <MetricInfo
+            trigger={
+              <div className="flex flex-nowrap items-center gap-1">
+                <StatusIcon status="queued" />
+                <span className="block">{queuedProofs.length}</span>
+              </div>
+            }
+          >
+            <span className="!font-body text-body">
+              Number of provers who have indicated intent to prove this block
+            </span>
+          </MetricInfo>
+        </div>
+      )}
+    </figure>
   )
 }
 

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -27,7 +27,7 @@ export const ProofStatusInfo = () => (
 
 type ProofStatusProps = React.HTMLAttributes<HTMLDivElement> & {
   proofs: Proof[]
-  hideEmpty: boolean
+  hideEmpty?: boolean
 }
 const ProofStatus = ({
   proofs,

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 
 import { MetricInfo } from "./ui/metric"
 import { TooltipContentHeader } from "./ui/tooltip"
+import StatusIcon from "./StatusIcon"
 
 import { isCompleted } from "@/lib/proofs"
 
@@ -14,14 +15,11 @@ export const ProofStatusInfo = () => (
   <>
     <TooltipContentHeader>proof status</TooltipContentHeader>
     <div className="items-top grid grid-cols-[auto,1fr] gap-4">
-      <Box strokeWidth="1" className="self-center text-2xl text-primary" />
+      <StatusIcon status="proved" />
       Number of completed proofs that have been published for this block
-      <BoxDashed className="self-center text-2xl text-primary" />
+      <StatusIcon status="proving" />
       Number of provers currently generating proofs for this block
-      <Box
-        strokeWidth="1"
-        className="self-center text-2xl text-body-secondary"
-      />
+      <StatusIcon status="queued" />
       Number of provers who have indicated intent to prove this block
     </div>
     <p className="text-body-secondary">
@@ -47,7 +45,7 @@ const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
         <MetricInfo
           trigger={
             <div className="flex flex-nowrap items-center gap-1">
-              <Box strokeWidth="1" className="text-primary" />
+              <StatusIcon status="proved" />
               <span className="block">{completedProofs.length}</span>
             </div>
           }
@@ -61,7 +59,7 @@ const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
         <MetricInfo
           trigger={
             <div className="flex flex-nowrap items-center gap-1">
-              <BoxDashed strokeWidth="1" className="text-primary" />
+              <StatusIcon status="proving" />
               <span className="block">{provingProofs.length}</span>
             </div>
           }
@@ -75,7 +73,7 @@ const ProofStatus = ({ proofs, className, ...props }: ProofStatusProps) => {
         <MetricInfo
           trigger={
             <div className="flex flex-nowrap items-center gap-1">
-              <Box strokeWidth="1" className="text-body-secondary" />
+              <StatusIcon status="queued" />
               <span className="block">{queuedProofs.length}</span>
             </div>
           }

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -1,8 +1,5 @@
 import type { Proof } from "@/lib/types"
 
-import Box from "@/components/svgs/box.svg"
-import BoxDashed from "@/components/svgs/box-dashed.svg"
-
 import { cn } from "@/lib/utils"
 
 import { MetricInfo } from "./ui/metric"

--- a/components/StatusIcon.tsx
+++ b/components/StatusIcon.tsx
@@ -17,8 +17,8 @@ const statusVariants = cva("self-center text-2xl text-body-secondary", {
 })
 
 const StatusIcon = React.forwardRef<
-  HTMLOrSVGElement,
-  React.HTMLAttributes<HTMLOrSVGElement> & VariantProps<typeof statusVariants>
+  SVGElement,
+  React.HTMLAttributes<SVGElement> & VariantProps<typeof statusVariants>
 >(({ className, status, ...props }, ref) => {
   const Icon = status === "queued" ? BoxDashed : Box
   return (

--- a/components/StatusIcon.tsx
+++ b/components/StatusIcon.tsx
@@ -1,0 +1,35 @@
+import * as React from "react"
+import { cva, VariantProps } from "class-variance-authority"
+
+import Box from "@/components/svgs/box.svg"
+import BoxDashed from "@/components/svgs/box-dashed.svg"
+
+import { cn } from "@/lib/utils"
+
+const statusVariants = cva("self-center text-2xl text-body-secondary", {
+  variants: {
+    status: {
+      queued: "",
+      proving: "",
+      proved: "text-primary",
+    },
+  },
+})
+
+const StatusIcon = React.forwardRef<
+  HTMLOrSVGElement,
+  React.HTMLAttributes<HTMLOrSVGElement> & VariantProps<typeof statusVariants>
+>(({ className, status, ...props }, ref) => {
+  const Icon = status === "queued" ? BoxDashed : Box
+  return (
+    <Icon
+      ref={ref}
+      strokeWidth="1"
+      className={cn(statusVariants({ status, className }))}
+      {...props}
+    />
+  )
+})
+StatusIcon.displayName = "StatusIcon"
+
+export default StatusIcon

--- a/components/ui/metric.tsx
+++ b/components/ui/metric.tsx
@@ -36,9 +36,11 @@ const MetricInfo = React.forwardRef<HTMLDivElement, MetricInfoProps>(
   ({ trigger, className, children, ...props }, ref) => (
     <Tooltip
       trigger={
-        <div className="ms-2">
-          {trigger || <InfoCircle className="-mb-0.5" />}
-        </div>
+        trigger || (
+          <div className="ms-2">
+            <InfoCircle className="-mb-0.5" />
+          </div>
+        )
       }
       className="max-w-80 sm:max-w-96"
     >

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -156,3 +156,24 @@ export const sortProofsStatusAndTimes = (a: Proof, b: Proof) => {
   }
   return 0
 }
+
+export const downloadProof = (proof: Proof) => {
+  const { proof: binary, proof_id, block_number, team, machine_id } = proof
+
+  if (!binary) {
+    console.warn("Download failed - no proof binary found")
+    console.warn(`Block: ${block_number}, Proof ID: ${proof_id}`)
+    return
+  }
+
+  const teamName = team?.team_name ? team.team_name : machine_id.split("-")[0]
+  const suggestedFilename = `${block_number}_${teamName}_${proof_id}.bin`
+
+  const blob = new Blob([binary], { type: "application/octet-stream" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = suggestedFilename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,8 @@ import { type ReactNode } from "react"
 
 import type { Tables } from "./database.types"
 
+export type Team = Tables<"teams">
+
 export type Proof = Tables<"proofs">
 export type Block = Tables<"blocks">
 export type EmptyBlock = Partial<Block> & Pick<Block, "block_number">


### PR DESCRIPTION
## Description
Reworks the new `ProofStatus` component
- Adds `StatusIcon` component with `status` variants 
- Usage: `<StatusIcon status="proved | proving | queued" />` with optional `className` styling

Creates new `DownloadButton` component
- Uses `Button` styling as base
- When "proved", button active
- If "proved" but no `proof` binary found, button will be disabled (shouldn't happen?)
- When "proving", tooltip describes, no onClick, and icon is animated with "pulse"
- When "queued", tooltip describes, no onClick

`downloadProof` function added, and attached to active Download button mentioned above

Includes proposal for design change:
- Use gray dashed stroke box for "queued"
- Use gray solid stroke box for "proving"
- Use green/primary solid stroke box for "proved"

This feels more additive as the process progresses. Gray and dashed > gains solid stroke > gains green color. Versus existing which is gray and solid > now green but regresses with dashed stroke > still green, gains solid stroke

<img width="453" alt="image" src="https://github.com/user-attachments/assets/0c75d117-7129-4813-8c8b-5e31b58bcbab">
<img width="504" alt="image" src="https://github.com/user-attachments/assets/7e585fcf-594e-46be-b370-eb377b29802e">
<img width="1568" alt="image" src="https://github.com/user-attachments/assets/19586823-432d-492c-9c63-57607841c4c1">
