### PR TITLE
fix: provers grid layout and fallback images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -182,7 +182,7 @@ export default async function Index() {
                     />
                     <div
                       className={cn(
-                        "absolute inset-0 grid place-items-center text-2xl",
+                        "absolute inset-0 grid place-items-center text-4xl",
                         logo_url && "sr-only"
                       )}
                     >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,7 +155,12 @@ export default async function Index() {
             </div>
           )}
         </div>
-        <div className="flex flex-wrap gap-8">
+        <div
+          className="grid gap-8"
+          style={{
+            gridTemplateColumns: "repeat(auto-fill, minmax(24rem, 1fr))",
+          }}
+        >
           {teamsSummary.data &&
             teamsSummary.data.map(
               ({
@@ -166,7 +171,7 @@ export default async function Index() {
                 average_proof_latency,
               }) => (
                 <div
-                  className="flex min-w-96 flex-1 flex-col gap-4 rounded-4xl border bg-gradient-to-b from-body/[0.06] to-body/[0.03] p-8"
+                  className="flex flex-col gap-4 rounded-4xl border bg-gradient-to-b from-body/[0.06] to-body/[0.03] p-8"
                   key={team_id}
                 >
                   <div className="relative mx-auto flex h-20 w-56 justify-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -173,16 +173,16 @@ export default async function Index() {
                     <TeamLogo
                       src={logo_url}
                       alt={team_name || "Prover logo"}
-                      className="object-center"
+                      className={cn("object-center", !logo_url && "opacity-50")}
                     />
-                    <span
+                    <div
                       className={cn(
-                        "absolute inset-0 text-2xl",
-                        !logo_url && "sr-only"
+                        "absolute inset-0 grid place-items-center text-2xl",
+                        logo_url && "sr-only"
                       )}
                     >
                       {team_name}
-                    </span>
+                    </div>
                   </div>
 
                   <div className="mx-auto flex flex-col gap-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -180,14 +180,14 @@ export default async function Index() {
                       alt={team_name || "Prover logo"}
                       className={cn("object-center", !logo_url && "opacity-50")}
                     />
-                    <div
+                    <h3
                       className={cn(
-                        "absolute inset-0 grid place-items-center text-4xl",
+                        "absolute inset-0 grid place-items-center text-3xl",
                         logo_url && "sr-only"
                       )}
                     >
                       {team_name}
-                    </div>
+                    </h3>
                   </div>
 
                   <div className="mx-auto flex flex-col gap-6">


### PR DESCRIPTION
Fixes:
https://main--ethproofs.netlify.app/#provers
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/cff86275-ffe8-40b5-be9a-41cd9580feeb">

With:
https://deploy-preview-125--ethproofs.netlify.app/#provers
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/f82a7f9c-3a86-4c0e-a263-64e28dd8a09a">