### PR TITLE
Metrics and definitions abstraction

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -7,7 +7,7 @@ import type { Metric } from "@/lib/types"
 
 import CopyButton from "@/components/CopyButton"
 import DownloadButton from "@/components/DownloadButton"
-import * as Metrics from "@/components/Metrics"
+import { metrics } from "@/components/Metrics"
 import Null from "@/components/Null"
 import ProofStatus, { ProofStatusInfo } from "@/components/ProofStatus"
 import { HidePunctuation } from "@/components/StylePunctuation"
@@ -119,14 +119,18 @@ export default async function BlockDetailsPage({
       value: <ProofStatus proofs={proofs} />,
     },
     {
-      label: `Fastest ${Metrics.PROVING_TIME_LABEL}`,
+      label: (
+        <>
+          Fastest <metrics.provingTime.Label />
+        </>
+      ),
       // TODO: Include team information with fastest proving time
       description: (
         <>
           <TooltipContentHeader>
-            fastest {Metrics.PROVING_TIME_LABEL}
+            fastest <metrics.provingTime.Label />
           </TooltipContentHeader>
-          <Metrics.ProvingTimeDetails />
+          <metrics.provingTime.Details />
           <Info.Description>
             Fastest reported proving time for any of the proofs submitted for
             this block
@@ -140,36 +144,34 @@ export default async function BlockDetailsPage({
       ),
     },
     {
-      label: `avg ${Metrics.PROVING_TIME_LABEL}`,
+      label: (
+        <>
+          avg <metrics.provingTime.Label />
+        </>
+      ),
       description: (
         <>
           <TooltipContentHeader>
-            average {Metrics.PROVING_TIME_LABEL}
+            average <metrics.provingTime.Label />
           </TooltipContentHeader>
-          <Metrics.ProvingTimeDetails average />
+          <metrics.provingTime.Details average />
         </>
       ),
       value: avgProvingTime ? prettyMilliseconds(avgProvingTime) : <Null />,
     },
     {
-      label: "Fastest time to proof",
+      label: (
+        <>
+          Fastest <metrics.totalTTP.Label />
+        </>
+      ),
       // TODO: Include team information with fastest proving time
       description: (
         <>
-          <TooltipContentHeader>fastest time to proof</TooltipContentHeader>
-          <Info.Derivation>
-            <Info.Term type="internal">proof submission time</Info.Term> -{" "}
-            <Info.Term type="codeTerm">timestamp</Info.Term>
-          </Info.Derivation>
-          <p>
-            <Info.Term type="internal">proof submission time</Info.Term> is the
-            timestamp logged by {SITE_NAME} when a completed proof has been
-            submitted
-          </p>
-          <p>
-            <Info.Term type="codeTerm">timestamp</Info.Term> value from
-            execution block header
-          </p>
+          <TooltipContentHeader>
+            fastest <metrics.totalTTP.Label />
+          </TooltipContentHeader>
+          <metrics.totalTTP.Details />
           <Info.Description>
             Total time delay between execution block timestamp and completion
             and publishing of proof
@@ -183,24 +185,17 @@ export default async function BlockDetailsPage({
         bestTimeToProof > 0 ? prettyMilliseconds(bestTimeToProof) : <Null />,
     },
     {
-      label: "avg time to proof",
+      label: (
+        <>
+          Avg <metrics.totalTTP.Label />
+        </>
+      ),
       description: (
         <>
-          <TooltipContentHeader>average time to proof</TooltipContentHeader>
-          <Info.Derivation>
-            ∑(<Info.Term type="internal">proof submission time</Info.Term> -{" "}
-            <Info.Term type="codeTerm">timestamp</Info.Term>) / number of
-            completed proofs for block
-          </Info.Derivation>
-          <p>
-            <Info.Term type="internal">proof submission time</Info.Term> is the
-            timestamp logged by {SITE_NAME} when a completed proof has been
-            submitted
-          </p>
-          <p>
-            <Info.Term type="codeTerm">timestamp</Info.Term> value from
-            execution block header
-          </p>
+          <TooltipContentHeader>
+            average <metrics.totalTTP.Label />
+          </TooltipContentHeader>
+          <metrics.totalTTP.Details average />
           <Info.Description>
             Total time delay between execution block timestamp and completion
             and publishing of proof
@@ -220,11 +215,17 @@ export default async function BlockDetailsPage({
 
   const blockFeeMetrics: Metric[] = [
     {
-      label: "cheapest cost per proof",
+      label: (
+        <>
+          cheapest <metrics.costPerProof.Label />
+        </>
+      ),
       description: (
         <>
-          <TooltipContentHeader>cheapest cost per proof</TooltipContentHeader>
-          <Metrics.ProvingCostsDetails />
+          <TooltipContentHeader>
+            cheapest <metrics.costPerProof.Label />
+          </TooltipContentHeader>
+          <metrics.provingCosts.Details />
         </>
       ),
       value: cheapestProof?.proving_cost ? (
@@ -237,11 +238,15 @@ export default async function BlockDetailsPage({
       ),
     },
     {
-      label: "avg cost per proof",
+      label: (
+        <>
+          avg <metrics.costPerProof.Label />
+        </>
+      ),
       description: (
         <>
           <TooltipContentHeader>avg cost per proof</TooltipContentHeader>
-          <Metrics.ProvingCostsDetails average />
+          <metrics.provingCosts.Details average />
         </>
       ),
       value: avgCostPerProof ? (
@@ -254,13 +259,17 @@ export default async function BlockDetailsPage({
       ),
     },
     {
-      label: <>cheapest {Metrics.COST_PER_MGAS_LABEL}</>,
+      label: (
+        <>
+          cheapest <metrics.costPerMgas.Label />
+        </>
+      ),
       description: (
         <>
           <TooltipContentHeader>
-            cheapest {Metrics.COST_PER_MGAS_LABEL}
+            cheapest <metrics.costPerMgas.Label />
           </TooltipContentHeader>
-          <Metrics.CostPerMgas />
+          <metrics.costPerMgas.Details />
         </>
       ),
       value:
@@ -274,13 +283,17 @@ export default async function BlockDetailsPage({
         ),
     },
     {
-      label: <>avg {Metrics.COST_PER_MGAS_LABEL}</>,
+      label: (
+        <>
+          avg <metrics.costPerMgas.Label />
+        </>
+      ),
       description: (
         <>
           <TooltipContentHeader>
-            avg {Metrics.COST_PER_MGAS_LABEL}
+            avg <metrics.costPerMgas.Label />
           </TooltipContentHeader>
-          <Metrics.CostPerMgas />
+          <metrics.costPerMgas.Details />
         </>
       ),
       value:
@@ -460,30 +473,12 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel>
-                  time to proof
+                  <metrics.totalTTP.Label />
                   <MetricInfo>
-                    <TooltipContentHeader>time to proof</TooltipContentHeader>
-                    <Info.Derivation>
-                      <Info.Term type="internal">
-                        proof submission time
-                      </Info.Term>{" "}
-                      - <Info.Term type="codeTerm">timestamp</Info.Term>
-                    </Info.Derivation>
-                    <p>
-                      <Info.Term type="internal">
-                        proof submission time
-                      </Info.Term>{" "}
-                      is the timestamp logged by {SITE_NAME} when a completed
-                      proof has been submitted
-                    </p>
-                    <p>
-                      <Info.Term type="codeTerm">timestamp</Info.Term> value
-                      from execution block header
-                    </p>
-                    <Info.Description>
-                      Total time delay between execution block timestamp and
-                      completion and publishing of proof
-                    </Info.Description>
+                    <TooltipContentHeader>
+                      <metrics.totalTTP.Label />
+                    </TooltipContentHeader>
+                    <metrics.totalTTP.Details />
                   </MetricInfo>
                 </MetricLabel>
                 <MetricValue className="font-normal">
@@ -502,10 +497,12 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel>
-                  proving time
+                  <metrics.provingTime.Label />
                   <MetricInfo>
-                    <TooltipContentHeader>proving time</TooltipContentHeader>
-                    <Metrics.ProvingTimeDetails />
+                    <TooltipContentHeader>
+                      <metrics.provingTime.Label />
+                    </TooltipContentHeader>
+                    <metrics.provingTime.Details />
                   </MetricInfo>
                 </MetricLabel>
                 <MetricValue className="font-normal">
@@ -575,21 +572,12 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel className="sm:max-md:justify-end">
-                  proving costs
+                  <metrics.provingCosts.Label />
                   <MetricInfo>
-                    <TooltipContentHeader>proving costs</TooltipContentHeader>
-                    <Info.Derivation>
-                      <Info.Term type="internal">proving costs</Info.Term>
-                    </Info.Derivation>
-                    <p>
-                      <Info.Term type="internal">proving costs</Info.Term> are
-                      in USD, self-reported by{" "}
-                      {team?.team_name ? team.team_name : "proving team"}
-                    </p>
-                    <Info.Description>
-                      Proving costs are in USD, and represent the self-reported
-                      expenditures included in proving this block
-                    </Info.Description>
+                    <TooltipContentHeader>
+                      <metrics.provingCosts.Label />
+                    </TooltipContentHeader>
+                    <metrics.provingCosts.Details />
                   </MetricInfo>
                 </MetricLabel>
                 <MetricValue className="font-normal">

--- a/app/prover/[teamId]/columns.tsx
+++ b/app/prover/[teamId]/columns.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 import prettyMilliseconds from "pretty-ms"
 import { ColumnDef } from "@tanstack/react-table"
 
-import type { ProofExtended } from "@/lib/types"
+import type { Proof } from "@/lib/types"
 
 import DownloadButton from "@/components/DownloadButton"
 import * as Metrics from "@/components/Metrics"
@@ -15,7 +15,6 @@ import { ColumnHeader } from "./ColumnHeader"
 
 import { formatNumber } from "@/lib/number"
 
-export const columns: ColumnDef<ProofExtended>[] = [
   // Block (time since)
   {
     accessorKey: "block_number",

--- a/app/prover/[teamId]/columns.tsx
+++ b/app/prover/[teamId]/columns.tsx
@@ -7,7 +7,7 @@ import { ColumnDef } from "@tanstack/react-table"
 import type { Proof } from "@/lib/types"
 
 import DownloadButton from "@/components/DownloadButton"
-import * as Metrics from "@/components/Metrics"
+import { metrics } from "@/components/Metrics"
 import Null from "@/components/Null"
 import { HidePunctuation } from "@/components/StylePunctuation"
 
@@ -15,12 +15,16 @@ import { ColumnHeader } from "./ColumnHeader"
 
 import { formatNumber } from "@/lib/number"
 
+export const columns: ColumnDef<Proof>[] = [
   // Block (time since)
   {
     accessorKey: "block_number",
     header: () => (
-      <ColumnHeader label={Metrics.BLOCK_NUMBER_LABEL} className="text-start">
-        <Metrics.BlockNumberDetails />
+      <ColumnHeader
+        label={<metrics.blockNumber.Label />}
+        className="text-start"
+      >
+        <metrics.blockNumber.Details />
       </ColumnHeader>
     ),
     cell: ({ cell }) => {
@@ -41,8 +45,8 @@ import { formatNumber } from "@/lib/number"
   {
     accessorKey: "cluster.cluster_name",
     header: () => (
-      <ColumnHeader label={Metrics.CLUSTER_LABEL}>
-        <Metrics.ClusterDetails />
+      <ColumnHeader label={<metrics.cluster.Label />}>
+        <metrics.cluster.Details />
       </ColumnHeader>
     ),
     cell: ({ cell }) => {
@@ -55,8 +59,8 @@ import { formatNumber } from "@/lib/number"
   {
     accessorKey: "proved_timestamp",
     header: () => (
-      <ColumnHeader label={Metrics.TOTAL_TTP_LABEL}>
-        <Metrics.TotalTTPDetails />
+      <ColumnHeader label={<metrics.totalTTP.Label />}>
+        <metrics.totalTTP.Details />
       </ColumnHeader>
     ),
     cell: ({ cell, row }) => {
@@ -75,8 +79,8 @@ import { formatNumber } from "@/lib/number"
   {
     accessorKey: "proving_time",
     header: () => (
-      <ColumnHeader label={Metrics.PROVING_TIME_LABEL}>
-        <Metrics.ProvingTimeDetails />
+      <ColumnHeader label={<metrics.provingTime.Label />}>
+        <metrics.provingTime.Details />
       </ColumnHeader>
     ),
     cell: ({ cell }) => {

--- a/app/prover/[teamId]/page.tsx
+++ b/app/prover/[teamId]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import prettyMilliseconds from "pretty-ms"
 
-import type { Metric, ProofExtended, ProverCluster } from "@/lib/types"
+import type { ClusterBase, Metric, Proof } from "@/lib/types"
 
 import Null from "@/components/Null"
 import ProofStatus, { ProofStatusInfo } from "@/components/ProofStatus"
@@ -95,7 +95,7 @@ export default async function ProverPage({ params }: ProverPageProps) {
         [curr.cluster.cluster_id]: curr.cluster,
       }
     }, {})
-  ) satisfies ProverCluster[]
+  ) satisfies ClusterBase[]
 
   const completedProofs = proofsExtended.filter(
     (p) => p.proof_status === "proved"
@@ -115,13 +115,13 @@ export default async function ProverPage({ params }: ProverPageProps) {
   )
   const avgCostPerMgas = proverTotalFees / totalGasProven / 1e6
 
-  const avgProofProvingTime = getProofsAvgProvingTime(proofsExtended)
+  const avgProofProvingTime = getProofsAvgProvingTime(proofsExtended as Proof[])
 
   const performanceMetrics: Metric[] = [
     {
       label: "Total proofs",
       description: <ProofStatusInfo title="total proofs" />,
-      value: <ProofStatus proofs={proofsExtended} />,
+      value: <ProofStatus proofs={proofsExtended as Proof[]} />,
     },
     {
       label: (
@@ -251,7 +251,7 @@ export default async function ProverPage({ params }: ProverPageProps) {
         </h2>
         <DataTable
           columns={columns}
-          data={proofsExtended as ProofExtended[]}
+          data={proofsExtended as Proof[]}
           sorting={[{ id: "block_number", desc: true }]}
         />
       </section>

--- a/components/BlocksTable/ClusterDetails.tsx
+++ b/components/BlocksTable/ClusterDetails.tsx
@@ -1,6 +1,6 @@
-import type { ProofExtended } from "@/lib/types"
+import type { Proof } from "@/lib/types"
 
-const ClusterDetails = ({ proof }: { proof: ProofExtended }) => {
+const ClusterDetails = ({ proof }: { proof: Proof }) => {
   const { cluster_id, cluster } = proof
   if (!cluster) return "Cluster " + cluster_id.split("-")[0]
   const { cluster_description, cluster_hardware, cluster_name } = cluster

--- a/components/BlocksTable/TeamName.tsx
+++ b/components/BlocksTable/TeamName.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link"
 
-import type { ProofExtended } from "@/lib/types"
+import type { Proof } from "@/lib/types"
 
-const TeamName = ({ proof: { team, user_id } }: { proof: ProofExtended }) => {
+const TeamName = ({ proof: { team, user_id } }: { proof: Proof }) => {
   if (!team) return `Team ${user_id.split("-")[0]}`
   return (
     <Link

--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -6,7 +6,7 @@ import { ColumnDef } from "@tanstack/react-table"
 
 import type { BlockWithProofs, Proof } from "@/lib/types"
 
-import * as Metrics from "@/components/Metrics"
+import { metrics } from "@/components/Metrics"
 import Null from "@/components/Null"
 import ArrowRight from "@/components/svgs/arrow-right.svg"
 import Award from "@/components/svgs/award.svg"
@@ -41,8 +41,8 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   {
     accessorKey: "block_number",
     header: () => (
-      <ColumnHeader label={Metrics.BLOCK_NUMBER_LABEL} className="text-left">
-        <Metrics.BlockNumberDetails />
+      <ColumnHeader label={<metrics.blockNumber.Label />} className="text-left">
+        <metrics.blockNumber.Details />
         <TooltipContentFooter className="space-y-3">
           <p className="font-bold">Time since block published</p>
           <Info.Derivation>
@@ -82,8 +82,8 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   {
     accessorKey: "gas_used",
     header: () => (
-      <ColumnHeader label={Metrics.GAS_USED_LABEL}>
-        <Metrics.GasUsedDetails />
+      <ColumnHeader label={<metrics.gasUsed.Label />}>
+        <metrics.gasUsed.Details />
         <TooltipContentFooter className="space-y-3">
           <p className="font-bold">Percentage of block gas limit</p>
           <Info.Derivation>
@@ -126,27 +126,12 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   },
   {
     accessorKey: "proofs",
-    header: () => {
-      const columnLabel = "cost per proof"
-      return (
-        <div className="whitespace-nowrap">
-          {columnLabel}
-          <MetricInfo className="space-y-3 whitespace-normal">
-            <TooltipContentHeader>{columnLabel}</TooltipContentHeader>
-            <Info.Derivation>
-              <Info.Term type="internal">proving costs</Info.Term>
-            </Info.Derivation>
-            <p>
-              <Info.Term type="internal">proving costs</Info.Term> are in USD,
-              self-reported by proving teams
-            </p>
-            <Info.Description>
-              Proving costs in USD to prove entire block
-            </Info.Description>
-          </MetricInfo>
-        </div>
-      )
-    },
+    header: () => (
+      <ColumnHeader label={<metrics.costPerProof.Label />}>
+        <metrics.costPerProof.Details />
+      </ColumnHeader>
+    ),
+
     cell: ({ cell }) => {
       const proofs = cell.getValue() as Proof[]
       if (!proofs.length) return <Null />
@@ -194,8 +179,8 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   {
     accessorKey: "proofs",
     header: () => (
-      <ColumnHeader label={Metrics.COST_PER_MGAS_LABEL}>
-        <Metrics.CostPerMgas />
+      <ColumnHeader label={<metrics.costPerMgas.Label />}>
+        <metrics.costPerMgas.Details />
       </ColumnHeader>
     ),
     cell: ({ cell, row }) => {
@@ -246,8 +231,8 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   {
     accessorKey: "proofs",
     header: () => (
-      <ColumnHeader label={Metrics.PROVING_TIME_LABEL}>
-        <Metrics.ProvingTimeDetails />
+      <ColumnHeader label={<metrics.provingTime.Label />}>
+        <metrics.provingTime.Details />
       </ColumnHeader>
     ),
     cell: ({ cell, row }) => {
@@ -309,18 +294,15 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
   {
     accessorKey: "proofs",
     header: () => (
-      <div className="whitespace-nowrap">
-        <span className="lowercase">{Metrics.TOTAL_TTP_LABEL}</span>
-        <MetricInfo className="whitespace-normal">
-          <ProofStatusInfo />
-          <TooltipContentFooter className="space-y-3">
-            <Info.Label isSecondary>
-              {Metrics.TOTAL_TTP_LABEL} (fastest proof shown)
-            </Info.Label>
-            <Metrics.TotalTTPDetails />
-          </TooltipContentFooter>
-        </MetricInfo>
-      </div>
+      <ColumnHeader label={<metrics.totalTTP.Label />}>
+        <ProofStatusInfo />
+        <TooltipContentFooter className="space-y-3">
+          <Info.Label isSecondary>
+            <metrics.totalTTP.Label /> (fastest proof shown)
+          </Info.Label>
+          <metrics.totalTTP.Details />
+        </TooltipContentFooter>
+      </ColumnHeader>
     ),
     cell: ({ cell, row }) => {
       const proofs = cell.getValue() as Proof[]
@@ -354,7 +336,9 @@ export const columns: ColumnDef<BlockWithProofs>[] = [
         <div className="flex flex-col justify-center text-center">
           <ProofStatus className="mx-auto" proofs={proofs} />
           <div className="whitespace-nowrap text-xs text-body-secondary">
-            <span className="font-body">time to proof:</span>{" "}
+            <span className="font-body">
+              <metrics.totalTTP.Label />:
+            </span>{" "}
             {earliestSubmissionTime
               ? formatted(msAfterBlock(earliestSubmissionTime))
               : "-"}

--- a/components/Definitions.tsx
+++ b/components/Definitions.tsx
@@ -1,0 +1,179 @@
+import * as Info from "@/components/ui/info"
+
+import { SITE_NAME } from "@/lib/constants"
+
+type DefinitionDetails = {
+  displayName?: string
+  Term: () => React.ReactNode
+  Definition: () => React.ReactNode
+}
+
+const PRIMITIVES = {
+  hourlyPrice: "hourly price",
+  provingTime: "proving time",
+  gasUsed: "gas used",
+  blockNumber: "block number",
+  proofSubmissionTime: "proof submission time",
+  timestamp: "timestamp",
+  cluster: "cluster",
+} as const
+
+type Primitive = keyof typeof PRIMITIVES
+
+const primitives: Record<Primitive, DefinitionDetails> = {
+  hourlyPrice: {
+    displayName: PRIMITIVES.hourlyPrice,
+    Term: () => <Info.Term type="internal">{PRIMITIVES.hourlyPrice}</Info.Term>,
+    Definition: () => (
+      <p>
+        <Info.Term type="internal">{PRIMITIVES.hourlyPrice}</Info.Term> is the
+        per-hour USD rate charged by AWS for the cluster of hardware
+        most-equivalent to that being used by the prover
+      </p>
+    ),
+  },
+  provingTime: {
+    displayName: PRIMITIVES.provingTime,
+    Term: () => <Info.Term type="internal">{PRIMITIVES.provingTime}</Info.Term>,
+    Definition: () => (
+      <p>
+        <Info.Term type="internal">{PRIMITIVES.provingTime}</Info.Term> is
+        duration of computation time during the proof generation process, self
+        reported by proving teams in milliseconds
+      </p>
+    ),
+  },
+  gasUsed: {
+    displayName: PRIMITIVES.gasUsed,
+    Term: () => <Info.Term type="codeTerm">{PRIMITIVES.gasUsed}</Info.Term>,
+    Definition: () => (
+      <p>
+        <Info.Term type="codeTerm">{PRIMITIVES.gasUsed}</Info.Term> value from
+        execution block header
+      </p>
+    ),
+  },
+  blockNumber: {
+    displayName: PRIMITIVES.blockNumber,
+    Term: () => <Info.Term type="codeTerm">{PRIMITIVES.blockNumber}</Info.Term>,
+    Definition: () => (
+      <p>
+        <Info.Term type="codeTerm">{PRIMITIVES.blockNumber}</Info.Term> value
+        from execution block header
+      </p>
+    ),
+  },
+  proofSubmissionTime: {
+    displayName: PRIMITIVES.proofSubmissionTime,
+    Term: () => (
+      <Info.Term type="internal">{PRIMITIVES.proofSubmissionTime}</Info.Term>
+    ),
+    Definition: () => (
+      <p>
+        <Info.Term type="internal">{PRIMITIVES.proofSubmissionTime}</Info.Term>{" "}
+        is the timestamp logged by {SITE_NAME} when a completed proof has been
+        submitted
+      </p>
+    ),
+  },
+  timestamp: {
+    displayName: PRIMITIVES.timestamp,
+    Term: () => <Info.Term type="codeTerm">{PRIMITIVES.timestamp}</Info.Term>,
+    Definition: () => (
+      <p>
+        <Info.Term type="codeTerm">{PRIMITIVES.timestamp}</Info.Term> value from
+        execution block header
+      </p>
+    ),
+  },
+  cluster: {
+    displayName: PRIMITIVES.cluster,
+    Term: () => <Info.Term type="codeTerm">{PRIMITIVES.cluster}</Info.Term>,
+    Definition: () => (
+      <p>
+        <Info.Term type="codeTerm">{PRIMITIVES.cluster}</Info.Term> is the
+        unique set of hardware being used to generate the proof identifier, self
+        reported as AWS instance equivalents
+      </p>
+    ),
+  },
+}
+
+const CONVERSIONS = {
+  gasPerMgas: "gas per Mgas",
+  msToHours: "milliseconds to hours",
+} as const
+
+type Conversion = keyof typeof CONVERSIONS
+
+const conversions: Record<Conversion, DefinitionDetails> = {
+  gasPerMgas: {
+    displayName: CONVERSIONS.gasPerMgas,
+    Term: () => (
+      <Info.Term type="codeTerm">
+        10<sup>6</sup>
+      </Info.Term>
+    ),
+    Definition: () => (
+      <p>
+        Divide by{" "}
+        <Info.Term type="codeTerm">
+          10<sup>6</sup>
+        </Info.Term>{" "}
+        to convert gas to megagas (Mgas)
+      </p>
+    ),
+  },
+  msToHours: {
+    displayName: CONVERSIONS.msToHours,
+    Term: () => <Info.Term type="codeTerm">(1000 * 60 * 60)</Info.Term>,
+    Definition: () => (
+      <p>
+        Divide by <Info.Term type="codeTerm">(1000 * 60 * 60)</Info.Term> to
+        convert milliseconds to hours
+      </p>
+    ),
+  },
+}
+
+const COMPUTED = {
+  provingCosts: "proving costs",
+  mgas: "mgas",
+} as const
+
+type Computed = keyof typeof COMPUTED
+
+const computed: Record<Computed, DefinitionDetails> = {
+  provingCosts: {
+    displayName: COMPUTED.provingCosts,
+    Term: () => (
+      <>
+        <primitives.hourlyPrice.Term /> * <primitives.provingTime.Term /> /{" "}
+        <conversions.msToHours.Term />
+      </>
+    ),
+    Definition: () => (
+      <>
+        <primitives.hourlyPrice.Definition />
+        <primitives.provingTime.Definition />
+        <conversions.msToHours.Definition />
+      </>
+    ),
+  },
+  mgas: {
+    displayName: "mgas",
+    Term: () => (
+      <>
+        <primitives.gasUsed.Term /> / <conversions.gasPerMgas.Term />
+      </>
+    ),
+    Definition: () => (
+      <>
+        <primitives.gasUsed.Definition />
+        <conversions.gasPerMgas.Definition />
+      </>
+    ),
+  },
+}
+
+export { computed, conversions, primitives }

--- a/components/Metrics.tsx
+++ b/components/Metrics.tsx
@@ -1,187 +1,172 @@
 import * as Info from "@/components/ui/info"
 
-import { SITE_NAME } from "@/lib/constants"
+import { computed, primitives } from "./Definitions"
 
-const BLOCK_NUMBER_LABEL = "block"
-const CLUSTER_LABEL = "cluster"
-const GAS_USED_LABEL = "gas used"
-const PROVING_COSTS_LABEL = "proving costs"
-const PROVING_TIME_LABEL = "proving time"
-const TOTAL_TTP_LABEL = "total time to proof"
-const COST_PER_MGAS_LABEL = (
-  <>
-    cost per <span className="uppercase">m</span>gas
-  </>
-)
-
-const BlockNumberDetails = () => {
-  const blockNumber = "block_number"
-  return (
-    <>
-      <Info.Derivation>
-        <Info.Term type="codeTerm">{blockNumber}</Info.Term>
-      </Info.Derivation>
-      <p>
-        <Info.Term type="codeTerm">{blockNumber}</Info.Term> value from
-        execution block header
-      </p>
-      <Info.Description>Block height number</Info.Description>
-    </>
-  )
+type Props = {
+  average?: boolean
+}
+export type ColumnDetails = {
+  Label: (props: Props) => React.ReactNode
+  Details: (props: Props) => React.ReactNode
 }
 
-const ClusterDetails = () => {
-  const cluster = "cluster"
-  return (
+const METRICS = {
+  blockNumber: "block",
+  cluster: "cluster",
+  gasUsed: "gas used",
+  provingCosts: "proving costs",
+  provingTime: "proving time",
+  totalTTP: "total time to proof",
+  costPerMgas: (
     <>
-      <Info.Derivation>
-        <Info.Term type="codeTerm">{cluster}</Info.Term>
-      </Info.Derivation>
-      <p>
-        <Info.Term type="codeTerm">{cluster}</Info.Term> is the unique set of
-        hardware being used to generate the proof identifier, self reported as
-        AWS instance equivalents
-      </p>
-      <Info.Description>Cluster identifier</Info.Description>
+      cost per <span className="uppercase">m</span>gas
     </>
-  )
-}
+  ),
+  costPerProof: "cost per proof",
+} as const
 
-const CostPerMgas = () => {
-  const provingCosts = "proving costs"
-  const gasUsed = "gas_used"
-  return (
-    <>
-      <Info.Derivation>
-        <Info.Term type="internal">{provingCosts}</Info.Term> /{" "}
-        <Info.Term type="codeTerm">{gasUsed}</Info.Term> /{" "}
-        <Info.Term type="codeTerm">
-          10
-          <sup>6</sup>
-        </Info.Term>
-      </Info.Derivation>
+type Metric = keyof typeof METRICS
 
-      <p>
-        <Info.Term type="internal">proving costs</Info.Term> are in USD,
-        self-reported by proving teams
-      </p>
-      <p>
-        <Info.Term type="codeTerm">gas_used</Info.Term> value from execution
-        block header, expressed in millions
-      </p>
-      <Info.Description>
-        Proving costs in USD per million gas units proven
-      </Info.Description>
-      <Info.Description>
-        Normalized USD cost per gas unit to allow comparison amongst proofs of
-        different sized blocks. More gas consumption in a block means more
-        computation to prove.
-      </Info.Description>
-    </>
-  )
-}
+const metrics: Record<Metric, ColumnDetails> = {
+  blockNumber: {
+    Label: () => METRICS.blockNumber,
+    Details: () => (
+      <>
+        <Info.Derivation>
+          <primitives.blockNumber.Term />
+        </Info.Derivation>
 
-const GasUsedDetails = () => {
-  const gasUsed = "gas_used"
-  return (
-    <>
-      <Info.Derivation>
-        <Info.Term type="codeTerm">{gasUsed}</Info.Term>
-      </Info.Derivation>
-      <p>
-        <Info.Term type="codeTerm">{gasUsed}</Info.Term> value from execution
-        block header
-      </p>
-      <Info.Description>Total gas units executed within block</Info.Description>
-      <Info.Description>
-        Proportional to the amount of computational effort a block outputs. Less
-        gas = less computationally intense = easier to prove.
-      </Info.Description>
-    </>
-  )
-}
+        <primitives.blockNumber.Definition />
 
-const ProvingCostsDetails = ({ average }: { average?: boolean }) => {
-  const provingCosts = "proving costs"
-  return (
-    <>
-      <Info.Derivation>
-        {average ? "∑(" : ""}
-        <Info.Term type="internal">{provingCosts}</Info.Term>
-        {average ? ") / number of completed proofs for block" : ""}
-      </Info.Derivation>
-      <p>
-        <Info.Term type="internal">{provingCosts}</Info.Term> are in USD,
-        self-reported by proving teams
-      </p>
-      <Info.Description>
-        Proving costs in USD to prove entire block
-      </Info.Description>
-    </>
-  )
-}
+        <Info.Description>Block height number</Info.Description>
+      </>
+    ),
+  },
+  cluster: {
+    Label: () => METRICS.cluster,
+    Details: () => (
+      <>
+        <Info.Derivation>
+          <primitives.cluster.Term />
+        </Info.Derivation>
 
-const ProvingTimeDetails = ({ average }: { average?: boolean }) => {
-  const provingTime = "proving time"
-  return (
-    <>
-      <Info.Derivation>
-        {average ? "∑(" : ""}
-        <Info.Term type="internal">{provingTime}</Info.Term>
-        {average ? ") / number of completed proofs for block" : ""}
-      </Info.Derivation>
-      <p>
-        <Info.Term type="internal">{provingTime}</Info.Term> is duration of the
-        proof generation process, self reported by proving teams
-      </p>
-      <Info.Description>
-        Time spent generating proof of execution
-      </Info.Description>
-      {average ? (
+        <primitives.cluster.Definition />
+
+        <Info.Description>Cluster identifier</Info.Description>
+      </>
+    ),
+  },
+  gasUsed: {
+    Label: () => METRICS.gasUsed,
+    Details: () => (
+      <>
+        <Info.Derivation>
+          <primitives.gasUsed.Term />
+        </Info.Derivation>
+
+        <primitives.gasUsed.Definition />
+
         <Info.Description>
-          Average reported proving time for all completed proofs submitted for
-          this block
+          Total gas units executed within block
         </Info.Description>
-      ) : null}
-    </>
-  )
+        <Info.Description>
+          Proportional to the amount of computational effort a block outputs.
+          Less gas = less computationally intense = easier to prove.
+        </Info.Description>
+      </>
+    ),
+  },
+  provingCosts: {
+    Label: () => METRICS.provingCosts,
+    Details: () => (
+      <>
+        <Info.Derivation>
+          <computed.provingCosts.Term />
+        </Info.Derivation>
+
+        <computed.provingCosts.Definition />
+
+        <Info.Description>
+          Proving costs in USD to prove entire block
+        </Info.Description>
+      </>
+    ),
+  },
+  provingTime: {
+    Label: () => METRICS.provingTime,
+    Details: ({ average }) => (
+      <>
+        <Info.Derivation>
+          {average ? "∑(" : ""}
+          <primitives.provingTime.Term />
+          {average ? ") / number of completed proofs for block" : ""}
+        </Info.Derivation>
+
+        <primitives.provingTime.Definition />
+
+        <Info.Description>
+          Time spent generating proof of execution
+        </Info.Description>
+
+        {average ? (
+          <Info.Description>
+            Average reported proving time for all completed proofs submitted for
+            this block
+          </Info.Description>
+        ) : null}
+      </>
+    ),
+  },
+  totalTTP: {
+    Label: () => METRICS.totalTTP,
+    Details: ({ average }) => (
+      <>
+        <Info.Derivation>
+          {average ? "∑(" : ""}
+          <primitives.proofSubmissionTime.Term /> -{" "}
+          <primitives.timestamp.Term />
+          {average ? ") / number of completed proofs for block" : ""}
+        </Info.Derivation>
+
+        <primitives.proofSubmissionTime.Definition />
+        <primitives.timestamp.Definition />
+      </>
+    ),
+  },
+  costPerMgas: {
+    Label: () => METRICS.costPerMgas,
+    Details: () => (
+      <>
+        <Info.Derivation>
+          <computed.provingCosts.Term /> / <computed.mgas.Term />
+        </Info.Derivation>
+
+        <computed.provingCosts.Definition />
+        <computed.mgas.Definition />
+
+        <Info.Description>
+          Proving costs in USD per million gas units proven
+        </Info.Description>
+        <Info.Description>
+          Normalized USD cost per gas unit to allow comparison amongst proofs of
+          different sized blocks. More gas consumption in a block means more
+          computation to prove.
+        </Info.Description>
+      </>
+    ),
+  },
+  costPerProof: {
+    Label: () => METRICS.costPerProof,
+    Details: () => (
+      <>
+        <Info.Derivation>
+          <computed.provingCosts.Term />
+        </Info.Derivation>
+
+        <computed.provingCosts.Definition />
+      </>
+    ),
+  },
 }
 
-const TotalTTPDetails = () => {
-  const proofSubmissionTime = "proof submission time"
-  const timestamp = "timestamp"
-  return (
-    <>
-      <Info.Derivation>
-        <Info.Term type="internal">{proofSubmissionTime}</Info.Term> -{" "}
-        <Info.Term type="codeTerm">{timestamp}</Info.Term>
-      </Info.Derivation>
-      <p>
-        <Info.Term type="internal">{proofSubmissionTime}</Info.Term> is the
-        timestamp logged by {SITE_NAME} when a completed proof has been
-        submitted
-      </p>
-      <p>
-        <Info.Term type="codeTerm">{timestamp}</Info.Term> value from execution
-        block header
-      </p>
-    </>
-  )
-}
-
-export {
-  BLOCK_NUMBER_LABEL,
-  BlockNumberDetails,
-  CLUSTER_LABEL,
-  ClusterDetails,
-  COST_PER_MGAS_LABEL,
-  CostPerMgas,
-  GAS_USED_LABEL,
-  GasUsedDetails,
-  PROVING_COSTS_LABEL,
-  PROVING_TIME_LABEL,
-  ProvingCostsDetails,
-  ProvingTimeDetails,
-  TOTAL_TTP_LABEL,
-  TotalTTPDetails,
-}
+export { metrics }

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -1,4 +1,4 @@
-import type { BlockWithProofs, Proof, ProofExtended } from "./types"
+import type { BlockWithProofs, Proof } from "./types"
 
 export const isCompleted = (proof: Proof) => proof.proof_status === "proved"
 
@@ -155,7 +155,7 @@ export const sortProofsStatusAndTimes = (a: Proof, b: Proof) => {
   return 0
 }
 
-export const downloadProof = (proof: ProofExtended) => {
+export const downloadProof = (proof: Proof) => {
   const { proof: binary, proof_id, block_number, team, cluster_id } = proof
 
   if (!binary) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,19 +2,28 @@ import { type ReactNode } from "react"
 
 import type { Tables } from "./database.types"
 
+export type AwsInstance = Tables<"aws_instance_pricing">
+
 export type Block = Tables<"blocks">
 
-export type Proof = Tables<"proofs">
+export type ClusterBase = Tables<"clusters">
+export type ClusterExtensions = {
+  clusterConfig?: ClusterConfiguration
+  awsInstance?: AwsInstance
+}
+export type Cluster = ClusterBase & ClusterExtensions
+
+export type ClusterConfiguration = Tables<"cluster_configurations">
 
 export type Team = Tables<"teams">
 
-export type ProverCluster = Tables<"clusters">
-
-export type ProofExtended = Proof & {
+export type ProofBase = Tables<"proofs">
+export type ProofExtensions = {
+  block?: Block
+  cluster?: Cluster
   team?: Team
-  cluster?: ProverCluster | null
-  block?: Partial<Block> | null
 }
+export type Proof = ProofBase & ProofExtensions
 
 export type EmptyBlock = Partial<Block> & Pick<Block, "block_number">
 

--- a/supabase/seed/.snaplet/dataModel.json
+++ b/supabase/seed/.snaplet/dataModel.json
@@ -2109,24 +2109,6 @@
       "tableName": "messages",
       "fields": [
         {
-          "id": "realtime.messages.id",
-          "name": "id",
-          "columnName": "id",
-          "type": "int8",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": {
-            "identifier": "\"realtime\".\"messages_id_seq\"",
-            "increment": 1,
-            "start": 1
-          },
-          "hasDefaultValue": true,
-          "isId": true,
-          "maxLength": null
-        },
-        {
           "id": "realtime.messages.topic",
           "name": "topic",
           "columnName": "topic",
@@ -2155,16 +2137,44 @@
           "maxLength": null
         },
         {
-          "id": "realtime.messages.inserted_at",
-          "name": "inserted_at",
-          "columnName": "inserted_at",
-          "type": "timestamp",
-          "isRequired": true,
+          "id": "realtime.messages.payload",
+          "name": "payload",
+          "columnName": "payload",
+          "type": "jsonb",
+          "isRequired": false,
           "kind": "scalar",
           "isList": false,
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "realtime.messages.event",
+          "name": "event",
+          "columnName": "event",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "realtime.messages.private",
+          "name": "private",
+          "columnName": "private",
+          "type": "bool",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
         },
@@ -2178,8 +2188,36 @@
           "isList": false,
           "isGenerated": false,
           "sequence": false,
-          "hasDefaultValue": false,
+          "hasDefaultValue": true,
           "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "realtime.messages.inserted_at",
+          "name": "inserted_at",
+          "columnName": "inserted_at",
+          "type": "timestamp",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "realtime.messages.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "uuid",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": true,
           "maxLength": null
         }
       ],
@@ -2187,7 +2225,8 @@
         {
           "name": "messages_pkey",
           "fields": [
-            "id"
+            "id",
+            "inserted_at"
           ],
           "nullNotDistinct": false
         }
@@ -2395,6 +2434,20 @@
           "maxLength": null
         },
         {
+          "id": "auth.mfa_challenges.web_authn_session_data",
+          "name": "web_authn_session_data",
+          "columnName": "web_authn_session_data",
+          "type": "jsonb",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "name": "mfa_factors",
           "type": "mfa_factors",
           "isRequired": true,
@@ -2569,6 +2622,34 @@
           "maxLength": null
         },
         {
+          "id": "auth.mfa_factors.web_authn_credential",
+          "name": "web_authn_credential",
+          "columnName": "web_authn_credential",
+          "type": "jsonb",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "auth.mfa_factors.web_authn_aaguid",
+          "name": "web_authn_aaguid",
+          "columnName": "web_authn_aaguid",
+          "type": "uuid",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "name": "users",
           "type": "users",
           "isRequired": true,
@@ -2610,13 +2691,6 @@
           "nullNotDistinct": false
         },
         {
-          "name": "mfa_factors_phone_key",
-          "fields": [
-            "phone"
-          ],
-          "nullNotDistinct": false
-        },
-        {
           "name": "mfa_factors_pkey",
           "fields": [
             "id"
@@ -2632,7 +2706,7 @@
           "nullNotDistinct": false
         },
         {
-          "name": "unique_verified_phone_factor",
+          "name": "unique_phone_factor_per_user",
           "fields": [
             "phone",
             "user_id"
@@ -5633,6 +5707,20 @@
           "columnName": "notify_private_alpha",
           "type": "bool",
           "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "_realtime.tenants.private_only",
+          "name": "private_only",
+          "columnName": "private_only",
+          "type": "bool",
+          "isRequired": true,
           "kind": "scalar",
           "isList": false,
           "isGenerated": false,


### PR DESCRIPTION
## Description
- Abstracted the column metrics that we show into a component mapping exported from `@/components/Metrics`
- Implemented a similar `Definitions` exporter, which defines `primitive` values, `conversions` (such as ms to hours or gas to Mgas), and `calculated` values. These are used within column metric
- Re-used these components as much as possible to provide a canonical set of metrics with labels and term definitions and descriptions.

This includes updating the copy related to "proving costs" to match that of the new AWS model, however, the actualy `hourly_price` has not yet been pulled in via a linked `cluster_id` (TODO, can be separate PR).