### PR TITLE
Fix: "clusters" type

### DIFF
--- a/app/prover/[teamId]/page.tsx
+++ b/app/prover/[teamId]/page.tsx
@@ -81,7 +81,7 @@ export default async function ProverPage({ params }: ProverPageProps) {
 
   const { data: proofsExtended, error: proofError } = await supabase
     .from("proofs")
-    .select("*, cluster:clusters(*), block:blocks(gas_used,timestamp)")
+    .select("*, clusters(*), block:blocks(gas_used,timestamp)")
     .eq("user_id", team.user_id)
 
   if (!team || teamError || !proofsExtended?.length || proofError)
@@ -89,10 +89,10 @@ export default async function ProverPage({ params }: ProverPageProps) {
 
   const clusters = Object.values(
     proofsExtended.reduce((acc, curr) => {
-      if (!curr.cluster || !curr.cluster.index) return acc
+      if (!curr.clusters || !curr.clusters.index) return acc
       return {
         ...acc,
-        [curr.cluster.index]: curr.cluster,
+        [curr.clusters.index]: curr.clusters,
       }
     }, {})
   ) satisfies ClusterBase[]

--- a/components/BlocksTable/ClusterDetails.tsx
+++ b/components/BlocksTable/ClusterDetails.tsx
@@ -1,16 +1,16 @@
 import type { Proof } from "@/lib/types"
 
 const ClusterDetails = ({ proof }: { proof: Proof }) => {
-  const { cluster_id, cluster } = proof
+  const { cluster_id, clusters } = proof
 
-  if (!cluster)
+  if (!clusters)
     return (
       <span className="block text-lg font-semibold">
         Cluster {cluster_id.split("-")[0]}
       </span>
     )
 
-  const { description, hardware, nickname } = cluster
+  const { description, hardware, nickname } = clusters
 
   return (
     <div className="text-wrap">

--- a/components/BlocksTable/ClusterDetails.tsx
+++ b/components/BlocksTable/ClusterDetails.tsx
@@ -2,7 +2,14 @@ import type { Proof } from "@/lib/types"
 
 const ClusterDetails = ({ proof }: { proof: Proof }) => {
   const { cluster_id, cluster } = proof
-  if (!cluster) return "Cluster " + cluster_id.split("-")[0]
+
+  if (!cluster)
+    return (
+      <span className="block text-lg font-semibold">
+        Cluster {cluster_id.split("-")[0]}
+      </span>
+    )
+
   const { description, hardware, nickname } = cluster
 
   return (

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -19,7 +19,8 @@ export const isCompleted = (proof: Proof) => proof.proof_status === "proved"
  * @returns {boolean} `true` if information to calculate costs are available, otherwise `false`.
  */
 export const hasCostInfo = (p: Proof) =>
-  !!p.proving_time && !!p.cluster_configurations?.[0]?.awsInstance?.hourly_price
+  !!p.proving_time &&
+  !!p.cluster_configurations?.[0]?.aws_instance_pricing?.hourly_price
 
 /**
  * Determines if a proof has a valid proved timestamp.
@@ -126,7 +127,8 @@ export const getProofBestTimeToProof = (proofs: Proof[]): Proof | null => {
 export const getProvingCost = (proof: Proof): number | null => {
   const { proving_time, cluster_configurations } = proof
   // TODO: Remove [0] when 1:1 cluster_id to instance_type_id established
-  const { hourly_price } = cluster_configurations?.[0]?.awsInstance || {}
+  const { hourly_price } =
+    cluster_configurations?.[0]?.aws_instance_pricing || {}
   if (!proving_time || !hourly_price) return null
   return (proving_time * hourly_price) / 1e3 / 60 / 60
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,7 +36,7 @@ export type Team = Tables<"teams">
  * Extensions for the ClusterConfig type, adding optional awsInstance property.
  */
 export type ClusterConfigExtensions = {
-  awsInstance?: AwsInstance
+  aws_instance_pricing?: AwsInstance
 }
 
 /**
@@ -48,7 +48,7 @@ export type ClusterConfig = ClusterConfigBase & ClusterConfigExtensions
  * Extensions for the Cluster type, adding optional clusterConfig property.
  */
 export type ClusterExtensions = {
-  clusterConfig?: ClusterConfig
+  cluster_configurations?: ClusterConfig
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,7 @@ export type Team = Tables<"teams">
 export type ProofBase = Tables<"proofs">
 export type ProofExtensions = {
   block?: Block
-  cluster?: Cluster
+  clusters?: Cluster
   team?: Team
 }
 export type Proof = ProofBase & ProofExtensions

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -62,7 +62,7 @@ export type Cluster = ClusterBase & ClusterExtensions
 export type ProofExtensions = {
   cluster_configurations?: ClusterConfig[]
   block?: BlockBase
-  clusters?: Cluster
+  clusters?: Cluster | null
   team?: Team
 }
 

--- a/supabase/migrations/20241208063655_update_team_summary_view.sql
+++ b/supabase/migrations/20241208063655_update_team_summary_view.sql
@@ -1,0 +1,15 @@
+drop view if exists "public"."team_summary";
+
+create or replace view "public"."teams_summary" as
+  select "t"."team_id",
+    "t"."team_name",
+    "t"."logo_url",
+    "avg"(
+      cast(("a"."hourly_price" * "p"."proving_time") / (1000 * 60 * 60) as numeric)
+    ) as "avg_proving_cost",
+    "avg"("p"."proving_time") as "avg_proving_time"
+  from "teams" t
+    left join "proofs" p on "t"."user_id" = "p"."user_id" and "p"."proof_status" = 'proved' and "p"."proved_timestamp" >= now() - interval '30 days'
+    left join "cluster_configurations" cc on "p"."cluster_id" = cc."cluster_id"
+    left join "aws_instance_pricing" a on cc."instance_type_id" = "a"."id"
+  group by "t"."team_id";

--- a/supabase/seed/.snaplet/dataModel.json
+++ b/supabase/seed/.snaplet/dataModel.json
@@ -3215,20 +3215,6 @@
           "maxLength": null
         },
         {
-          "id": "public.proofs.proving_cost",
-          "name": "proving_cost",
-          "columnName": "proving_cost",
-          "type": "numeric",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.proofs.proving_cycles",
           "name": "proving_cycles",
           "columnName": "proving_cycles",
@@ -4722,6 +4708,50 @@
           "name": "secrets_name_idx",
           "fields": [
             "name"
+          ],
+          "nullNotDistinct": false
+        }
+      ]
+    },
+    "seed_files": {
+      "id": "supabase_migrations.seed_files",
+      "schemaName": "supabase_migrations",
+      "tableName": "seed_files",
+      "fields": [
+        {
+          "id": "supabase_migrations.seed_files.path",
+          "name": "path",
+          "columnName": "path",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "supabase_migrations.seed_files.hash",
+          "name": "hash",
+          "columnName": "hash",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": "seed_files_pkey",
+          "fields": [
+            "path"
           ],
           "nullNotDistinct": false
         }


### PR DESCRIPTION
## Description
The linkages in our databases allow us to easily nest fields from other related tables. 

```ts
    await supabase.from("blocks").select("*,proofs(*,clusters(*))")
```

This will automatically nest a `clusters` field, based on the table name being provided. By using these names in our type structures, we can easily accept data in this form without any remapping.

PR updates `cluster` to `clusters` to match table name; fixes the missing cluster information

Also fixes teamSummary query, updating with new proving costs logic (hourly rate * proving tim / msPerHour. Fixes the widget on homepage having zero results