### PR TITLE
Comment Out Zod Validation for Proof Payload

### DIFF
--- a/lib/zod/schemas/proof.ts
+++ b/lib/zod/schemas/proof.ts
@@ -27,8 +27,8 @@ export const provedProofSchema = baseProofSchema.extend({
     .optional()
     .describe("Number of cycles taken to generate the proof"),
   // Temporarily disable proof validation to test if its giving maximum call stack error
-  // proof: z
-  //   .string()
+  proof: z
+    .string(),
   //   .base64()
   //   .min(1, "proof is required for 'proved' status")
   //   .describe("Proof in base64 format"),

--- a/lib/zod/schemas/proof.ts
+++ b/lib/zod/schemas/proof.ts
@@ -26,10 +26,11 @@ export const provedProofSchema = baseProofSchema.extend({
     .positive("proving_cycles must be a positive integer")
     .optional()
     .describe("Number of cycles taken to generate the proof"),
-  proof: z
-    .string()
-    .base64()
-    .min(1, "proof is required for 'proved' status")
-    .describe("Proof in base64 format"),
+  // Temporarily disable proof validation to test if its giving maximum call stack error
+  // proof: z
+  //   .string()
+  //   .base64()
+  //   .min(1, "proof is required for 'proved' status")
+  //   .describe("Proof in base64 format"),
   verifier_id: z.string().optional().describe("vkey/image-id"),
 })


### PR DESCRIPTION
## Description

temporarily comments out the Zod validation for the `proof` field in the `provedProofSchema` to test the hypothesis that the validation of large proof payloads (e.g., 3.6 MB in size, base64-encoded) may be causing out-of-memory (OOM) issues or stack overflows in the POST request. specifically, the validation for proof using z.string().base64() has been identified as a potential source of the issue because:

1. the significant increase in payload size caused by base64 encoding (~33% larger).
1. the synchronous nature of Zod validation, which might not be suitable for extremely large strings in memory-constrained serverless environments.