### PR TITLE
Add lightweight base64 validation proof validation

### DIFF
--- a/lib/zod/schemas/proof.ts
+++ b/lib/zod/schemas/proof.ts
@@ -18,16 +18,19 @@ export const provingProofSchema = baseProofSchema.extend({})
 export const provedProofSchema = baseProofSchema.extend({
   proving_time: z
     .number()
-    .positive("proving_time must be a positive number"),
+    .positive("proving_time must be a positive number")
+    .describe("Milliseconds taken to generate the proof"),
   proving_cycles: z
     .number()
     .int()
     .positive("proving_cycles must be a positive integer")
-    .optional(),
+    .optional()
+    .describe("Number of cycles taken to generate the proof"),
   proof: z
     .string()
     .min(1, "proof is required for 'proved' status")
-    .refine((val) => isValidBase64(val), { message: "proof must be a valid base64 string" }),
+    .refine((val) => isValidBase64(val), { message: "proof must be a valid base64 string" })
+    .describe("Proof in base64 format"),
   verifier_id: z.string().optional(),
 });
 

--- a/lib/zod/schemas/proof.ts
+++ b/lib/zod/schemas/proof.ts
@@ -31,7 +31,7 @@ export const provedProofSchema = baseProofSchema.extend({
     .min(1, "proof is required for 'proved' status")
     .refine((val) => isValidBase64(val), { message: "proof must be a valid base64 string" })
     .describe("Proof in base64 format"),
-  verifier_id: z.string().optional(),
+  verifier_id: z.string().optional().describe("vkey/image-id"),
 });
 
 // validate base64 without decoding

--- a/lib/zod/schemas/proof.ts
+++ b/lib/zod/schemas/proof.ts
@@ -18,18 +18,22 @@ export const provingProofSchema = baseProofSchema.extend({})
 export const provedProofSchema = baseProofSchema.extend({
   proving_time: z
     .number()
-    .positive("proving_time must be a positive number")
-    .describe("Milliseconds taken to generate the proof"),
+    .positive("proving_time must be a positive number"),
   proving_cycles: z
     .number()
     .int()
     .positive("proving_cycles must be a positive integer")
-    .optional()
-    .describe("Number of cycles taken to generate the proof"),
+    .optional(),
   proof: z
     .string()
-    .base64()
     .min(1, "proof is required for 'proved' status")
-    .describe("Proof in base64 format"),
-  verifier_id: z.string().optional().describe("vkey/image-id"),
-})
+    .refine((val) => isValidBase64(val), { message: "proof must be a valid base64 string" }),
+  verifier_id: z.string().optional(),
+});
+
+// validate base64 without decoding
+// decoding with zod causing out of memory errors: https://github.com/ethproofs/ethproofs/pull/154
+const isValidBase64 = (str: string) => {
+  const base64Regex = /^[A-Za-z0-9+/]+={0,2}$/;
+  return base64Regex.test(str);
+};


### PR DESCRIPTION
## Description 
- updates the proof field validation to use a lightweight custom base64 validator instead of Zod's .base64() method.

## Why?

- Zod's .base64() method likely decodes the string internally, which can cause excessive memory usage when handling very large payloads (e.g., 3.6 MB base64 string in our testcase) and was the likely cause of OOM errors in our POST reqs