### PR TITLE
UI: Filter out new teams

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import { AVERAGE_LABEL } from "@/lib/constants"
 
 import { getMetadata } from "@/lib/metadata"
 import { formatNumber, formatUsd, shouldUseCents } from "@/lib/number"
-import { getTotalProvers } from "@/lib/teams"
+import { getActiveProverCount } from "@/lib/teams"
 import { prettyMs } from "@/lib/time"
 import HeroDark from "@/public/images/hero-background.png"
 import { createClient } from "@/utils/supabase/server"
@@ -191,7 +191,7 @@ export default async function Index() {
                 Prover diversity
               </div>
               <div className="flex items-center gap-2 whitespace-nowrap text-4xl text-primary">
-                <ShieldCheck /> {getTotalProvers(teamsSummary.data)}
+                <ShieldCheck /> {getActiveProverCount(teamsSummary.data)}
               </div>
               <div className="whitespace-nowrap text-xs font-bold uppercase text-body-secondary">
                 Prover vendors

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -1,0 +1,10 @@
+import type { TeamSummary } from "./types"
+
+/**
+ * Get total number of proving teams who have proof timing/cost data in summary
+ * (Actively proving teams)
+ * @param data array of rows (TeamSummary) from teams_summary view
+ * @returns
+ */
+export const getTotalProvers = (data: TeamSummary[]): number =>
+  data.filter((t) => !!t.avg_cost_per_proof && !!t.avg_proving_time).length

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -6,5 +6,5 @@ import type { TeamSummary } from "./types"
  * @param data array of rows (TeamSummary) from teams_summary view
  * @returns
  */
-export const getTotalProvers = (data: TeamSummary[]): number =>
+export const getActiveProverCount = (data: TeamSummary[]): number =>
   data.filter((t) => !!t.avg_cost_per_proof && !!t.avg_proving_time).length

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,6 +33,11 @@ export type ProofBase = Tables<"proofs">
 export type Team = Tables<"teams">
 
 /**
+ * Represents a row in the teams_summary view.
+ */
+export type TeamSummary = Tables<"teams_summary">
+
+/**
  * Extensions for the ClusterConfig type, adding optional awsInstance property.
  */
 export type ClusterConfigExtensions = {


### PR DESCRIPTION
## Description
Currently showing provers in this list even if they have not yet submitted any proofs. 

Proposing we:
- Update UI to show these teams as as new provers
- Hide the zero metrics and the CTA button (currently leading to a 404 page in staging for provers that don't have proofs yet), using  `PROVING SOON` in its place
- Not include these teams in the "prover diversity" count until they have at least one proof completed

Alternatively we could
- Hide new teams all together 👎
- Include them in the count anyway (👎 imo, less honest and less incentive to keep moving forward)

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/52695cc8-98cf-40f5-a141-2ae99678b425" />

## Related issue

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/931447c5-fa65-4eaa-982b-a313206ec084" />
