### PR TITLE
Fix bug where table page count shows as zero

### DIFF
--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -110,8 +110,8 @@ const DataTable = <TData, TValue>({
         </Button>
         <span className="flex items-center gap-1 font-mono uppercase text-body-secondary">
           <div>
-            Page {table.getState().pagination.pageIndex + 1} of{" "}
-            {table.getPageCount().toLocaleString()}
+          Page {table.getState().pagination.pageIndex + 1} of{" "}
+            {table.getPageCount() === 0 ? 1 : table.getPageCount().toLocaleString()}
           </div>
         </span>
         <Button


### PR DESCRIPTION
Fixes a bug, where if there are no results, it shows as page 1 of 0.

<img width="692" alt="Screenshot 2024-12-14 at 15 56 44" src="https://github.com/user-attachments/assets/f57c9dfd-b717-4b1f-aa2e-beeaeb779859" />
