### PR TITLE
Filter out proving teams from summary proving time is if null

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,6 +44,7 @@ export default async function Index() {
   const teamsSummary = await supabase
     .from("teams_summary")
     .select()
+    .filter("avg_proving_time", "is", null)
     .order("avg_proving_time", { ascending: true })
 
   const blocksResponse = await supabase


### PR DESCRIPTION
Filter out provers who are not contributing. If they have no average proving time then we can assume they have not submitted any proofs.