### PR TITLE
Fix, fetch cluster data in block page

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -87,7 +87,7 @@ export default async function BlockDetailsPage({
 
   const { data: block, error } = await supabase
     .from("blocks")
-    .select("*, proofs(*)")
+    .select("*, proofs(*,cluster:clusters(*,cluster_configurations(*,aws_instance_pricing(*))))")
     .eq(getBlockValueType(blockNumber), blockNumber)
     .single()
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,7 +36,7 @@ export type Team = Tables<"teams">
  * Extensions for the ClusterConfig type, adding optional awsInstance property.
  */
 export type ClusterConfigExtensions = {
-  aws_instance_pricing?: AwsInstance
+  aws_instance_pricing?: AwsInstance | null
 }
 
 /**


### PR DESCRIPTION
Currently there are no costs calculated in the page due to the lack of cluster related data.
![image](https://github.com/user-attachments/assets/fc3fb027-c0b6-4ec7-b422-b4a8cd7b628b)

After this fix:
![image](https://github.com/user-attachments/assets/3af20fe5-4f84-4e2a-8dd7-a21c69dc34ea)
