### PR TITLE
404 not found

### DIFF
--- a/app/block/[block]/not-found.tsx
+++ b/app/block/[block]/not-found.tsx
@@ -1,22 +1,11 @@
-import { headers } from "next/headers"
-
+import NotFoundTemplate from "@/components/NotFoundTemplate"
 import Box from "@/components/svgs/box.svg"
-import { HeroSection } from "@/components/ui/hero"
 
 export default async function NotFound() {
-  const headersList = await headers()
-  const pathSegments = headersList.get("referer")?.split("/") || []
-  const block = pathSegments[pathSegments.length - 1] || ""
-
   return (
-    <HeroSection className="space-y-4">
-      <h1 className="flex flex-col items-center gap-4 font-mono md:flex-row">
-        404 <Box strokeWidth="1" className="text-6xl text-primary" />{" "}
-        <div className="w-full truncate text-center">
-          {typeof block === "string" ? block : ""}
-        </div>
-      </h1>
-      <p className="text-center md:text-start">Proof not found</p>
-    </HeroSection>
+    <NotFoundTemplate
+      label="Proof"
+      icon={<Box strokeWidth="1" className="text-6xl text-primary" />}
+    />
   )
 }

--- a/app/block/[block]/not-found.tsx
+++ b/app/block/[block]/not-found.tsx
@@ -12,7 +12,9 @@ export default async function NotFound() {
     <HeroSection className="space-y-4">
       <h1 className="flex flex-col items-center gap-4 font-mono md:flex-row">
         404 <Box strokeWidth="1" className="text-6xl text-primary" />{" "}
-        {typeof block === "string" ? block : ""}
+        <div className="w-full truncate text-center">
+          {typeof block === "string" ? block : ""}
+        </div>
       </h1>
       <p className="text-center md:text-start">Proof not found</p>
     </HeroSection>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,20 +1,5 @@
-import { ButtonLink } from "@/components/ui/button"
-import { HeroSection } from "@/components/ui/hero"
+import NotFoundTemplate from "@/components/NotFoundTemplate"
 
 export default async function NotFound() {
-  return (
-    <>
-      <HeroSection className="space-y-4">
-        <h1 className="flex flex-col items-center gap-4 font-mono text-5xl md:flex-row">
-          404
-        </h1>
-        <p className="text-center font-mono md:text-start">Page not found</p>
-      </HeroSection>
-      <div className="justify-center p-6 max-md:flex">
-        <ButtonLink href="/" className="mx-auto h-fit w-fit" size="lg">
-          View all proofs
-        </ButtonLink>
-      </div>
-    </>
-  )
+  return <NotFoundTemplate />
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import { ButtonLink } from "@/components/ui/button"
+import { HeroSection } from "@/components/ui/hero"
+
+export default async function NotFound() {
+  return (
+    <>
+      <HeroSection className="space-y-4">
+        <h1 className="flex flex-col items-center gap-4 font-mono text-5xl md:flex-row">
+          404
+        </h1>
+        <p className="text-center font-mono md:text-start">Page not found</p>
+      </HeroSection>
+      <div className="justify-center p-6 max-md:flex">
+        <ButtonLink href="/" className="mx-auto h-fit w-fit" size="lg">
+          View all proofs
+        </ButtonLink>
+      </div>
+    </>
+  )
+}

--- a/app/prover/[teamId]/not-found.tsx
+++ b/app/prover/[teamId]/not-found.tsx
@@ -1,13 +1,11 @@
+import NotFoundTemplate from "@/components/NotFoundTemplate"
 import ProofCircle from "@/components/svgs/proof-circle.svg"
-import { HeroSection } from "@/components/ui/hero"
 
 export default async function NotFound() {
   return (
-    <HeroSection className="space-y-4">
-      <h1 className="flex flex-col items-center gap-4 font-mono md:flex-row">
-        404 <ProofCircle className="inline text-primary" />
-      </h1>
-      <p className="text-center md:text-start">Prover not found</p>
-    </HeroSection>
+    <NotFoundTemplate
+      icon={<ProofCircle className="inline text-primary" />}
+      label="Prover"
+    />
   )
 }

--- a/components/NotFoundTemplate.tsx
+++ b/components/NotFoundTemplate.tsx
@@ -1,0 +1,37 @@
+import { LinkProps } from "next/link"
+
+import { ButtonLink } from "./ui/button"
+import { HeroSection } from "./ui/hero"
+
+type NotFoundsTemplateProps = Partial<
+  Pick<React.HTMLAttributes<HTMLDivElement>, "children"> &
+    Pick<LinkProps, "href"> & {
+      icon: React.ReactNode
+      label: string
+    }
+>
+
+const NotFoundTemplate = ({
+  children = "View all proofs",
+  href = "/",
+  label = "Page",
+  icon,
+}: NotFoundsTemplateProps) => {
+  return (
+    <>
+      <HeroSection className="space-y-4">
+        <h1 className="flex flex-col items-center gap-4 font-mono md:flex-row">
+          404 {icon}
+        </h1>
+        <p className="text-center font-mono md:text-start">{label} not found</p>
+      </HeroSection>
+      <div className="justify-center p-6 max-md:flex">
+        <ButtonLink href={href} className="mx-auto h-fit w-fit" size="lg">
+          {children}
+        </ButtonLink>
+      </div>
+    </>
+  )
+}
+
+export default NotFoundTemplate


### PR DESCRIPTION
## Description
- Adds a `NotFoundTemplate` component to help keep `not-found.tsx` fallback pages consistent, and implements in the three `not-found.tsx` pages currently being used.

https://github.com/user-attachments/assets/946d02ab-fa05-4790-9b67-ebbc73eb1835

