### PR TITLE
fix: time formatting isSubMinute logic

### DIFF
--- a/lib/time.ts
+++ b/lib/time.ts
@@ -9,14 +9,14 @@ import prettyMilliseconds, { type Options } from "pretty-ms"
 export const prettyMs = (milliseconds: number, options?: Options): string => {
   if (milliseconds < 0) return "-"
 
-  const isSubMinute = milliseconds < 60_0000
+  const isSubMinute = milliseconds < 60_000
   const isSubSecond = milliseconds < 1_000
   const isSubMillisecond = milliseconds < 1
 
   const defaultOptions: Options = {
     separateMilliseconds: isSubSecond,
     formatSubMilliseconds: isSubMillisecond,
-    unitCount: isSubMinute ? 1 : 2,
+    unitCount: 2,
     keepDecimalsOnWholeSeconds: true,
     secondsDecimalDigits: isSubMinute ? 1 : 0,
     millisecondsDecimalDigits: isSubMillisecond ? 1 : 0,


### PR DESCRIPTION
## Description
- Fixes `isSubMinute` logic which was off by a factor of ten
- Updates unneeded `unitCount` logic, default to 2 (will only show one if sub-minute) 
- Shows seconds decimal only when no minute value present (isSubMinute === true)

Example renders:

<img width="186" alt="image" src="https://github.com/user-attachments/assets/28ae02d6-23fe-481b-8b4c-ce49c0a904a9" />