### PR TITLE
fix: Tooltip trigger region to include label

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -245,9 +245,9 @@ export default async function BlockDetailsPage({
     {
       key: "cheapest-cost-per-mgas",
       label: (
-        <>
+        <div>
           cheapest <metrics.costPerMgas.Label />
-        </>
+        </div>
       ),
       description: (
         <>
@@ -262,9 +262,9 @@ export default async function BlockDetailsPage({
     {
       key: "avg-cost-per-mgas",
       label: (
-        <>
+        <div>
           {AVERAGE_LABEL} <metrics.costPerMgas.Label />
-        </>
+        </div>
       ),
       description: (
         <>
@@ -349,8 +349,11 @@ export default async function BlockDetailsPage({
             {availabilityMetrics.map(({ key, label, description, value }) => (
               <MetricBox key={key}>
                 <MetricLabel className="lowercase">
-                  {label}
-                  <MetricInfo>{description}</MetricInfo>
+                  <MetricInfo
+                    label={<span className="lowercase">{label}</span>}
+                  >
+                    {description}
+                  </MetricInfo>
                 </MetricLabel>
                 <MetricValue className="font-normal">{value}</MetricValue>
               </MetricBox>
@@ -366,8 +369,11 @@ export default async function BlockDetailsPage({
             {blockFeeMetrics.map(({ key, label, description, value }) => (
               <MetricBox key={key}>
                 <MetricLabel>
-                  {label}
-                  <MetricInfo>{description}</MetricInfo>
+                  <MetricInfo
+                    label={<span className="lowercase">{label}</span>}
+                  >
+                    {description}
+                  </MetricInfo>
                 </MetricLabel>
                 <MetricValue className="font-normal">{value}</MetricValue>
               </MetricBox>
@@ -447,8 +453,7 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel>
-                  <metrics.totalTTP.Label />
-                  <MetricInfo>
+                  <MetricInfo label={<metrics.totalTTP.Label />}>
                     <TooltipContentHeader>
                       <metrics.totalTTP.Label />
                     </TooltipContentHeader>
@@ -471,8 +476,7 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel>
-                  <metrics.provingTime.Label />
-                  <MetricInfo>
+                  <MetricInfo label={<metrics.provingTime.Label />}>
                     <TooltipContentHeader>
                       <metrics.provingTime.Label />
                     </TooltipContentHeader>
@@ -495,9 +499,15 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel>
-                  <span className="normal-case">{team?.team_name}</span> zk
-                  <span className="uppercase">VM</span> cycles
-                  <MetricInfo>
+                  <MetricInfo
+                    label={
+                      <div>
+                        <span className="normal-case">{team?.team_name}</span>{" "}
+                        zk
+                        <span className="uppercase">VM</span> cycles
+                      </div>
+                    }
+                  >
                     <TooltipContentHeader>
                       <span className="normal-case">{team?.team_name}</span> zk
                       <span className="uppercase">VM</span> cycles
@@ -546,8 +556,7 @@ export default async function BlockDetailsPage({
                 )}
               >
                 <MetricLabel className="sm:max-md:justify-end">
-                  <metrics.costPerProof.Label />
-                  <MetricInfo>
+                  <MetricInfo label={<metrics.costPerProof.Label />}>
                     <TooltipContentHeader>
                       <metrics.costPerProof.Label />
                     </TooltipContentHeader>

--- a/app/prover/[teamId]/ColumnHeader.tsx
+++ b/app/prover/[teamId]/ColumnHeader.tsx
@@ -8,8 +8,10 @@ type ColumnHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
 }
 const ColumnHeader = ({ label, children, className }: ColumnHeaderProps) => (
   <div className={cn("whitespace-nowrap", className)}>
-    <span className="lowercase">{label}</span>
-    <MetricInfo className="space-y-3 whitespace-normal">
+    <MetricInfo
+      className="space-y-3 whitespace-normal"
+      label={<span className="lowercase">{label}</span>}
+    >
       <Info.Label className="lowercase">{label}</Info.Label>
       {children}
     </MetricInfo>

--- a/app/prover/[teamId]/columns.tsx
+++ b/app/prover/[teamId]/columns.tsx
@@ -78,7 +78,7 @@ export const columns: ColumnDef<Proof>[] = [
         <>
           <MetricInfo
             trigger={
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
                 {cluster.nickname}
                 <Cpu />
               </div>

--- a/app/prover/[teamId]/page.tsx
+++ b/app/prover/[teamId]/page.tsx
@@ -145,12 +145,12 @@ export default async function ProverPage({ params }: ProverPageProps) {
     {
       key: "avg-zkvm-cycles-per-mgas",
       label: (
-        <>
+        <div>
           <span className="normal-case">{team.team_name}</span> {AVERAGE_LABEL}{" "}
           zk
           <span className="uppercase">VM</span> cycles per{" "}
           <span className="uppercase">M</span>gas
-        </>
+        </div>
       ),
       description:
         "The average number of zkVM cycles required to prove a million gas units",
@@ -159,10 +159,10 @@ export default async function ProverPage({ params }: ProverPageProps) {
     {
       key: "avg-cost-per-mgas",
       label: (
-        <>
+        <div>
           <span className="normal-case">{team.team_name}</span> {AVERAGE_LABEL}{" "}
           cost per <span className="uppercase">M</span>gas
-        </>
+        </div>
       ),
       description: "The average cost incurred for proving a million gas units",
       value: formatUsd(avgCostPerMgas),
@@ -252,8 +252,7 @@ export default async function ProverPage({ params }: ProverPageProps) {
           {performanceMetrics.map(({ key, label, description, value }) => (
             <MetricBox key={key}>
               <MetricLabel>
-                {label}
-                <MetricInfo>{description}</MetricInfo>
+                <MetricInfo label={label}>{description}</MetricInfo>
               </MetricLabel>
               <MetricValue>{value}</MetricValue>
             </MetricBox>

--- a/components/BlocksTable/AvgBestMetric.tsx
+++ b/components/BlocksTable/AvgBestMetric.tsx
@@ -1,0 +1,32 @@
+import type { Stats } from "@/lib/types"
+
+import Award from "@/components/svgs/award.svg"
+import { MetricInfo } from "@/components/ui/metric"
+
+import { AVERAGE_LABEL } from "@/lib/constants"
+
+import ClusterDetails from "./ClusterDetails"
+import TeamName from "./TeamName"
+
+const AvgBestMetric = ({ stats }: { stats: Stats }) => (
+  <>
+    <span className="align-center flex justify-center whitespace-nowrap">
+      <MetricInfo
+        trigger={
+          <div className="flex items-center gap-1">
+            {stats.bestFormatted}
+            <Award className="text-primary hover:text-primary-light" />
+          </div>
+        }
+      >
+        <TeamName proof={stats.bestProof} />
+        <ClusterDetails proof={stats.bestProof} />
+      </MetricInfo>
+    </span>
+    <span className="block whitespace-nowrap text-sm text-body-secondary">
+      {AVERAGE_LABEL} {stats.avgFormatted}
+    </span>
+  </>
+)
+
+export default AvgBestMetric

--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -8,22 +8,19 @@ import type { Block, Proof } from "@/lib/types"
 import { metrics } from "@/components/Metrics"
 import Null from "@/components/Null"
 import ArrowRight from "@/components/svgs/arrow-right.svg"
-import Award from "@/components/svgs/award.svg"
 import { ButtonLink } from "@/components/ui/button"
 import * as Info from "@/components/ui/info"
 
 import { cn } from "@/lib/utils"
 
-import { AVERAGE_LABEL, BLOCK_GAS_LIMIT } from "@/lib/constants"
+import { BLOCK_GAS_LIMIT } from "@/lib/constants"
 
 import ProofStatus, { ProofStatusInfo } from "../ProofStatus"
 import { HidePunctuation } from "../StylePunctuation"
-import { MetricInfo } from "../ui/metric"
 import { Progress } from "../ui/progress"
 import { TooltipContentFooter } from "../ui/tooltip"
 
-import ClusterDetails from "./ClusterDetails"
-import TeamName from "./TeamName"
+import AvgBestMetric from "./AvgBestMetric"
 
 import { ColumnHeader } from "@/app/prover/[teamId]/ColumnHeader"
 import { formatTimeAgo } from "@/lib/date"
@@ -135,32 +132,11 @@ export const columns: ColumnDef<Block>[] = [
     cell: ({ cell }) => {
       const proofs = cell.getValue() as Proof[]
 
-      const costPerProofStats = getCostPerProofStats(proofs)
+      const stats = getCostPerProofStats(proofs)
 
-      if (!costPerProofStats) return <Null />
+      if (!stats) return <Null />
 
-      const { avgFormatted, bestFormatted, bestProof } = costPerProofStats
-
-      return (
-        <>
-          <span className="align-center flex justify-center whitespace-nowrap">
-            <MetricInfo
-              trigger={
-                <div className="flex items-center gap-1">
-                  {bestFormatted}
-                  <Award className="text-primary hover:text-primary-light" />
-                </div>
-              }
-            >
-              <TeamName proof={bestProof} />
-              <ClusterDetails proof={bestProof} />
-            </MetricInfo>
-          </span>
-          <span className="block whitespace-nowrap text-sm text-body-secondary">
-            {AVERAGE_LABEL} {avgFormatted}
-          </span>
-        </>
-      )
+      return <AvgBestMetric stats={stats} />
     },
   },
   // Cost per Mgas
@@ -174,30 +150,11 @@ export const columns: ColumnDef<Block>[] = [
     cell: ({ row }) => {
       const { proofs, gas_used } = row.original
 
-      const costPerMgasStats = getCostPerMgasStats(proofs, gas_used)
+      const stats = getCostPerMgasStats(proofs, gas_used)
 
-      if (!costPerMgasStats) return <Null />
+      if (!stats) return <Null />
 
-      const { avgFormatted, bestFormatted, bestProof } = costPerMgasStats
-
-      return (
-        <>
-          <span className="align-center flex justify-center whitespace-nowrap">
-            {bestFormatted}
-            <MetricInfo
-              trigger={
-                <Award className="text-primary hover:text-primary-light" />
-              }
-            >
-              <TeamName proof={bestProof} />
-              <ClusterDetails proof={bestProof} />
-            </MetricInfo>
-          </span>
-          <span className="block whitespace-nowrap text-sm text-body-secondary">
-            {AVERAGE_LABEL} {avgFormatted}
-          </span>
-        </>
-      )
+      return <AvgBestMetric stats={stats} />
     },
   },
   // Proving time
@@ -211,30 +168,11 @@ export const columns: ColumnDef<Block>[] = [
     cell: ({ cell }) => {
       const proofs = cell.getValue() as Proof[]
 
-      const provingTimeStats = getProvingTimeStats(proofs)
+      const stats = getProvingTimeStats(proofs)
 
-      if (!provingTimeStats) return <Null />
+      if (!stats) return <Null />
 
-      const { bestFormatted, avgFormatted, bestProof } = provingTimeStats
-
-      return (
-        <>
-          <span className="align-center flex justify-center whitespace-nowrap">
-            {bestFormatted}
-            <MetricInfo
-              trigger={
-                <Award className="text-primary hover:text-primary-light" />
-              }
-            >
-              <TeamName proof={bestProof} />
-              <ClusterDetails proof={bestProof} />
-            </MetricInfo>
-          </span>
-          <span className="block whitespace-nowrap text-sm text-body-secondary">
-            {AVERAGE_LABEL} {avgFormatted}
-          </span>
-        </>
-      )
+      return <AvgBestMetric stats={stats} />
     },
   },
   // Total TTP

--- a/components/ui/metric.tsx
+++ b/components/ui/metric.tsx
@@ -30,14 +30,16 @@ const MetricLabel = React.forwardRef<
 MetricLabel.displayName = "MetricLabel"
 
 type MetricInfoProps = React.HTMLAttributes<HTMLDivElement> & {
+  label?: React.ReactNode
   trigger?: React.ReactNode
 }
 const MetricInfo = React.forwardRef<HTMLDivElement, MetricInfoProps>(
-  ({ trigger, className, children, ...props }, ref) => (
+  ({ label, trigger, className, children, ...props }, ref) => (
     <Tooltip
       trigger={
         trigger || (
-          <div className="ms-2">
+          <div className="flex items-center gap-2">
+            {label}
             <InfoCircle className="-mb-0.5" />
           </div>
         )


### PR DESCRIPTION
## Description
- Extracts reusable `AvgBestMetric` component for BlockTable
- Component includes the **label + icon** inside the Tooltip trigger
- Implements component and uses `stats` naming to keep the BlockTable columns consistent
- Updates ui/metric's MetricInfo to accept a `label` prop, which will render inside the tooltip trigger
- Moved existing labels that accompanied MetricInfo to the `label` prop to include in the trigger