### PR TITLE
fix: update eslint unused var/arg ignore pattern

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,8 +56,8 @@
       "warn",
       {
         "args": "all",
-        "argsIgnorePattern": "^_$",
-        "varsIgnorePattern": "^_$"
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
       }
     ]
   }


### PR DESCRIPTION
## Description
- Ignores any args/vars _prefixed_ with `_`, not just equal to `_`

Using `/^_$/` requires the arg/var to be named exactly `_` to be ignored, which can only be used once per scope. This pattern allows any prefixed variable to be ignored.

## Related issue

Fixes:

```
./app/api/v0/proofs/download/[id]/route.ts
4:3  Warning: '_request' is defined but never used. Allowed unused args must match /^_$/u.  unused-imports/no-unused-vars
```