### PR TITLE
404 not-found: root, /block/[block]; 500 error: /block/[block]

### DIFF
--- a/app/block/[block]/error.tsx
+++ b/app/block/[block]/error.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Box from "@/components/svgs/box.svg"
+import { ButtonLink } from "@/components/ui/button"
+import { Divider } from "@/components/ui/divider"
+import Link from "@/components/ui/link"
+
+import { SITE_REPO } from "@/lib/constants"
+
+export default function Error() {
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <Box className="size-40 stroke-[0.5px] text-body-secondary" />
+      <h1 className="mb-4 font-mono text-3xl text-primary">
+        Block not recognized
+      </h1>
+      <p className="text-lg">
+        The block provided is not a valid number or a hash
+      </p>
+      <p className="text-lg">
+        If this a bug please report on our{" "}
+        <Link href={new URL(SITE_REPO, "https://github.com").toString()}>
+          GitHub
+        </Link>{" "}
+        repo
+      </p>
+      <Divider className="my-6" />
+      <ButtonLink href="/" variant="outline" size="lg">
+        Back to homepage
+      </ButtonLink>
+    </div>
+  )
+}

--- a/app/block/[block]/not-found.tsx
+++ b/app/block/[block]/not-found.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation"
 
+import { HidePunctuation } from "@/components/StylePunctuation"
 import Box from "@/components/svgs/box.svg"
 import { ButtonLink } from "@/components/ui/button"
 import { Divider } from "@/components/ui/divider"
@@ -9,8 +10,12 @@ import Link from "@/components/ui/link"
 
 import { SITE_REPO } from "@/lib/constants"
 
+import { getBlockValueType } from "@/lib/blocks"
+import { formatNumber } from "@/lib/number"
+
 export default function NotFound() {
-  const { block } = useParams()
+  const block = useParams().block as string
+  const blockType = getBlockValueType(block)
 
   return (
     <div className="flex flex-col items-center gap-4 text-center">
@@ -19,8 +24,20 @@ export default function NotFound() {
         No block found with proofs
       </h1>
       <p className="text-lg">
-        The block {block} does not have proofs or was not proven by any of our
-        supported providers
+        The block{" "}
+        {blockType === "hash" ? (
+          <>
+            with hash{" "}
+            <span className="break-all font-mono text-body-secondary">
+              {block}
+            </span>
+          </>
+        ) : (
+          <span className="text-body-secondary">
+            <HidePunctuation>{formatNumber(+block)}</HidePunctuation>
+          </span>
+        )}{" "}
+        does not have proofs or was not proven by any of our supported providers
       </p>
       <p className="text-lg">
         If this a bug please report on our{" "}

--- a/app/block/[block]/not-found.tsx
+++ b/app/block/[block]/not-found.tsx
@@ -23,7 +23,7 @@ export default function NotFound() {
       <h1 className="mb-4 font-mono text-3xl text-primary">
         No block found with proofs
       </h1>
-      <p className="text-lg">
+      <p className="max-w-screen-lg text-lg">
         The block{" "}
         {blockType === "hash" ? (
           <>

--- a/app/block/[block]/not-found.tsx
+++ b/app/block/[block]/not-found.tsx
@@ -1,3 +1,7 @@
+"use client"
+
+import { useParams } from "next/navigation"
+
 import Box from "@/components/svgs/box.svg"
 import { ButtonLink } from "@/components/ui/button"
 import { Divider } from "@/components/ui/divider"
@@ -5,7 +9,9 @@ import Link from "@/components/ui/link"
 
 import { SITE_REPO } from "@/lib/constants"
 
-export default async function NotFound() {
+export default function NotFound() {
+  const { block } = useParams()
+
   return (
     <div className="flex flex-col items-center gap-4 text-center">
       <Box className="size-40 stroke-[0.5px] text-body-secondary" />
@@ -13,7 +19,7 @@ export default async function NotFound() {
         No block found with proofs
       </h1>
       <p className="text-lg">
-        This block does not have proofs or was not proven by any of our
+        The block {block} does not have proofs or was not proven by any of our
         supported providers
       </p>
       <p className="text-lg">

--- a/app/block/[block]/not-found.tsx
+++ b/app/block/[block]/not-found.tsx
@@ -1,11 +1,32 @@
-import NotFoundTemplate from "@/components/NotFoundTemplate"
 import Box from "@/components/svgs/box.svg"
+import { ButtonLink } from "@/components/ui/button"
+import { Divider } from "@/components/ui/divider"
+import Link from "@/components/ui/link"
+
+import { SITE_REPO } from "@/lib/constants"
 
 export default async function NotFound() {
   return (
-    <NotFoundTemplate
-      label="Proof"
-      icon={<Box strokeWidth="1" className="text-6xl text-primary" />}
-    />
+    <div className="flex flex-col items-center gap-4 text-center">
+      <Box className="size-40 stroke-[0.5px] text-body-secondary" />
+      <h1 className="mb-4 font-mono text-3xl text-primary">
+        No block found with proofs
+      </h1>
+      <p className="text-lg">
+        This block does not have proofs or was not proven by any of our
+        supported providers
+      </p>
+      <p className="text-lg">
+        If this a bug please report on our{" "}
+        <Link href={new URL(SITE_REPO, "https://github.com").toString()}>
+          GitHub
+        </Link>{" "}
+        repo
+      </p>
+      <Divider className="my-6" />
+      <ButtonLink href="/" variant="outline" size="lg">
+        Back to homepage
+      </ButtonLink>
+    </div>
   )
 }

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -62,7 +62,7 @@ import {
 import { prettyMs } from "@/lib/time"
 
 type BlockDetailsPageProps = {
-  params: Promise<{ block: number }>
+  params: Promise<{ block: string }>
 }
 
 export async function generateMetadata({
@@ -71,6 +71,8 @@ export async function generateMetadata({
   const { block } = await params
 
   const blockValueType = getBlockValueType(block)
+  if (!blockValueType) throw new Error()
+
   const blockData = await db.query.blocks.findFirst({
     where: (blocks, { eq }) => eq(blocks[blockValueType], block),
     with: {
@@ -89,6 +91,7 @@ export default async function BlockDetailsPage({
   const blockNumber = (await params).block
 
   const blockValueType = getBlockValueType(blockNumber)
+  if (!blockValueType) throw new Error()
 
   const blockRaw = await db.query.blocks.findFirst({
     with: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import EthProofsLogo from "@/components/svgs/eth-proofs-logo.svg"
 import GitHub from "@/components/svgs/github.svg"
 import Hamburger from "@/components/svgs/hamburger.svg"
 import Heart from "@/components/svgs/heart.svg"
-import { Button } from "@/components/ui/button"
+import { Button, ButtonLink } from "@/components/ui/button"
 import {
   Drawer,
   DrawerClose,
@@ -177,17 +177,14 @@ export default function RootLayout({
             <main className="min-h-[50vh]">{children}</main>
 
             <footer className="mx-auto mt-16 flex max-w-prose flex-col items-center">
-              <Button asChild size="lg">
-                <Link
-                  href={new URL(SITE_REPO, "https://github.com").toString()}
-                  className="mb-12"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <GitHub className="size-6" />
-                  <span>Contribute to {SITE_NAME}</span>
-                </Link>
-              </Button>
+              <ButtonLink
+                size="lg"
+                href={new URL(SITE_REPO, "https://github.com").toString()}
+                className="mb-12"
+              >
+                <GitHub className="size-6" />
+                <span>Contribute to {SITE_NAME}</span>
+              </ButtonLink>
 
               <p className="mb-4 text-center">
                 Built with{" "}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,17 @@
-import NotFoundTemplate from "@/components/NotFoundTemplate"
+import TriangleAlert from "@/components/svgs/triangle-alert.svg"
+import { ButtonLink } from "@/components/ui/button"
+import { Divider } from "@/components/ui/divider"
 
 export default async function NotFound() {
-  return <NotFoundTemplate />
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <TriangleAlert className="size-40 stroke-[1.25px] text-primary" />
+      <h1 className="mb-4 font-mono font-normal text-primary">404</h1>
+      <p className="text-lg">Nothing here</p>
+      <Divider className="my-6" />
+      <ButtonLink href="/" variant="outline" size="lg">
+        Back to homepage
+      </ButtonLink>
+    </div>
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import ShieldCheck from "@/components/svgs/shield-check.svg"
 import TeamLogo from "@/components/TeamLogo"
 import { ButtonLink } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import { Divider } from "@/components/ui/divider"
 
 import { cn } from "@/lib/utils"
 
@@ -154,7 +155,7 @@ export default async function Index() {
       <section className="w-full scroll-m-20 space-y-8" id="provers">
         <div>
           <h2>Provers</h2>
-          <div className="h-0.5 w-full bg-gradient-to-r from-primary" />
+          <Divider className="h-0.5" />
         </div>
         <div className="flex flex-col-reverse gap-8 sm:flex-row">
           <div className="flex-1">

--- a/components/LearnMore.tsx
+++ b/components/LearnMore.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link"
 
+import { Divider } from "./ui/divider"
+
 export default function LearnMore() {
   return (
     <section>
       <h2 className="mt-32 text-5xl">Learn</h2>
-      <div className="h-px w-full bg-gradient-to-r from-primary" />
+      <Divider />
       <div className="my-16 grid grid-cols-1 gap-12 lg:grid-cols-2">
         <div className="flex w-full flex-col gap-8 rounded-4xl border-2 border-body/20 px-4 py-12">
           {/* TODO: Add card backgrounds */}

--- a/components/Markdown/Components.tsx
+++ b/components/Markdown/Components.tsx
@@ -3,6 +3,8 @@ import { type Components } from "react-markdown"
 
 import Link from "@/components/ui/link"
 
+import { Divider } from "../ui/divider"
+
 export const MarkdownComponents: Components = {
   a: ({ children, href }) => <Link href={href}>{children}</Link>,
   img: ({ src, alt }) => (
@@ -11,7 +13,7 @@ export const MarkdownComponents: Components = {
   h2: ({ children }) => (
     <div>
       <h2 className="text-4xl md:text-5xl">{children}</h2>
-      <div className="h-px w-full bg-gradient-to-r from-primary"></div>
+      <Divider />
     </div>
   ),
   h3: ({ children }) => <h3 className="!mt-16 text-3xl">{children}</h3>,

--- a/components/NotFoundTemplate.tsx
+++ b/components/NotFoundTemplate.tsx
@@ -1,7 +1,6 @@
-import { LinkProps } from "next/link"
-
 import { ButtonLink } from "./ui/button"
 import { HeroSection } from "./ui/hero"
+import { type LinkProps } from "./ui/link"
 
 type NotFoundsTemplateProps = Partial<
   Pick<React.HTMLAttributes<HTMLDivElement>, "children"> &

--- a/components/svgs/triangle-alert.svg
+++ b/components/svgs/triangle-alert.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-triangle-alert">
+<path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+<path d="M12 9v4"/>
+<path d="M12 17h.01"/>
+</svg>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
-import Link, { LinkProps } from "next/link"
 import { Slot } from "@radix-ui/react-slot"
+
+import Link, { type LinkProps } from "@/components/ui/link"
 
 import { cn } from "@/lib/utils"
 
@@ -133,7 +134,11 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       >
         <Link
           ref={ref}
-          className={cn("no-underline hover:no-underline", className)}
+          hideArrow
+          className={cn(
+            "font-body font-bold no-underline hover:no-underline",
+            className
+          )}
           {...linkProps}
         >
           {children}

--- a/components/ui/divider.tsx
+++ b/components/ui/divider.tsx
@@ -1,0 +1,17 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Divider = React.forwardRef<
+  HTMLDivElement,
+  Omit<React.HTMLAttributes<HTMLDivElement>, "children">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("h-px w-full bg-gradient-to-r from-primary", className)}
+    {...props}
+  />
+))
+Divider.displayName = "Divider"
+
+export { Divider }

--- a/components/ui/hero.tsx
+++ b/components/ui/hero.tsx
@@ -2,6 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+import { Divider } from "./divider"
+
 const HeroSection = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -29,11 +31,7 @@ const HeroDivider = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("my-8 h-px w-full bg-gradient-to-r from-primary", className)}
-    {...props}
-  />
+  <Divider ref={ref} className={cn("my-8", className)} {...props} />
 ))
 HeroDivider.displayName = "HeroDivider"
 

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -27,11 +27,18 @@ export const fetchBlockData = async (block_number: number) => {
 /**
  * Determines the type of value for a given block.
  *
- * @param block - The block parameter to evaluate.
- * @returns A string indicating the type of value: "hash" if the block number is greater than 0xffffffff, otherwise "block_number".
+ * @param block - The block parameter to evaluate in string format
+ * @returns null if not parsable to a number; "hash" if matching 64 hex chars, else "block_number"
  */
-export const getBlockValueType = (block: number) =>
-  block > 0xffffffff ? "hash" : "block_number"
+export const getBlockValueType = (
+  block: string
+): keyof Pick<Block, "hash" | "block_number"> | null => {
+  if (isNaN(+block)) return null
+
+  if (/^0x[0-9a-fA-F]{64}$/.test(block)) return "hash"
+
+  return "block_number"
+}
 
 export const mergeBlocksWithTeams = (blocks: Block[], teams: Team[]) => {
   return blocks.map((block) => {


### PR DESCRIPTION
## Description
- Builds on 404 `not-found` pages for root level and `/block/[block]/not-found.tsx` pages.
- Uses client-side `not-found.tsx` to enable `useParams` hook allowing us to display the block number attempts as `next/headers` was not working appropriately for this use case.
- Also adds `/block/[block]/error.tsx` page for block-specific 500 errors when the block param provided is not a number.
- Small refactors while building out including abstraction of a `Divider` component, and tweaking of the `ButtonLink` component inside `ui/button`.

## Preview link

| url | expected result |
|--------|--------|
| https://deploy-preview-204--ethproofs.netlify.app/derp | root 404 |
| https://deploy-preview-204--ethproofs.netlify.app/block/ | root 404 |
| https://deploy-preview-204--ethproofs.netlify.app/block/0 | block 404 |
| [https://deploy-preview-204--ethproofs.netlify.app/block/0x5fb...61b](https://deploy-preview-204--ethproofs.netlify.app/block/0x5fbcafafb0deaeff0c9b23f6f3d27f9eebd8a8e05aca2fe5dfbf5bb88da5161b) | block 404 (valid hash pattern, no match |
| https://deploy-preview-204--ethproofs.netlify.app/block/derp | block 500 (not a number) | 

## Figma
https://www.figma.com/design/HE0ZQ8ISCCuwkPy6iot9m3/ETHProofs-site?node-id=5409-26839&m=dev

## Related issue
- Fixes #174 