### PR TITLE
chore: update proof download filename extension

### DIFF
--- a/app/api/v0/proofs/download/[id]/route.ts
+++ b/app/api/v0/proofs/download/[id]/route.ts
@@ -30,7 +30,7 @@ export async function GET(
   })
 
   const teamName = team?.name ? team.name : proofRow.cluster_id.split("-")[0]
-  const filename = `${proofRow.block_number}_${teamName}_${id}.bin`
+  const filename = `${proofRow.block_number}_${teamName}_${id}.txt`
 
   const binaryBuffer = Buffer.from(
     proofRow.proof_binary.proof_binary.slice(2),


### PR DESCRIPTION
.txt universally supported, being used when proofs exported within "download all" path