### PR TITLE
Various UI patches

### DIFF
--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -369,12 +369,15 @@ export default async function BlockDetailsPage({
           <h2 className="flex items-center gap-2 text-lg font-normal text-primary">
             <Timer /> Proof availability
           </h2>
-          <div className="grid grid-cols-2 gap-x-8 sm:flex sm:flex-wrap">
+          <div className="grid grid-cols-2 gap-x-8 sm:grid-cols-[repeat(5,auto)] sm:grid-rows-[auto,auto] md:flex md:flex-wrap">
             {availabilityMetrics.map(({ key, label, description, value }) => (
-              <MetricBox key={key}>
-                <MetricLabel className="lowercase">
+              <MetricBox
+                key={key}
+                className="row-span-2 grid grid-rows-subgrid"
+              >
+                <MetricLabel className="flex items-stretch lowercase">
                   <MetricInfo
-                    label={<span className="lowercase">{label}</span>}
+                    label={<span className="h-full lowercase">{label}</span>}
                   >
                     {description}
                   </MetricInfo>
@@ -391,7 +394,10 @@ export default async function BlockDetailsPage({
           </h2>
           <div className="grid grid-cols-2 gap-x-8 sm:flex sm:flex-wrap">
             {blockFeeMetrics.map(({ key, label, description, value }) => (
-              <MetricBox key={key}>
+              <MetricBox
+                key={key}
+                className="row-span-2 grid grid-rows-subgrid"
+              >
                 <MetricLabel>
                   <MetricInfo
                     label={<span className="lowercase">{label}</span>}

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -486,7 +486,7 @@ export default async function BlockDetailsPage({
                   proof={proof}
                   className="sm:max-md:w-40 lg:w-40"
                   labelClass="hidden sm:inline-block md:hidden lg:inline-block"
-                  containerClass="flex-row-reverse md:flex-col"
+                  containerClass="flex-row-reverse md:flex-col-reverse"
                 />
               </div>
               <MetricBox

--- a/app/block/[block]/page.tsx
+++ b/app/block/[block]/page.tsx
@@ -607,7 +607,7 @@ export default async function BlockDetailsPage({
                         {formatUsd(provingCost)} <Cpu />
                       </PopoverTrigger>
                       {cluster && clusterConfigs && (
-                        <PopoverContent className="w-[40rem] max-w-[100vw]">
+                        <PopoverContent>
                           <TooltipContentHeader>
                             {cluster.nickname}
                           </TooltipContentHeader>
@@ -630,7 +630,7 @@ export default async function BlockDetailsPage({
                             AWS Equivalency
                           </TooltipContentHeader>
 
-                          <div className="space-y-4">
+                          <div className="w-fit space-y-4">
                             {clusterConfigs.map(
                               ({
                                 instance_count,
@@ -654,7 +654,7 @@ export default async function BlockDetailsPage({
                                     key={instance_type_id}
                                   >
                                     <div className="flex gap-8">
-                                      <div className="space-y-2 p-2">
+                                      <div className="flex-1 space-y-2 p-2">
                                         {instance_memory && (
                                           <p>Memory: {instance_memory}</p>
                                         )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -90,11 +90,7 @@ export default async function Index() {
             </>
           ),
           icon: <Clock />,
-          value: (
-            <HidePunctuation>
-              {prettyMs(Number(recentSummary.avg_proving_time) || 0)}
-            </HidePunctuation>
-          ),
+          value: prettyMs(Number(recentSummary.avg_proving_time) || 0),
         },
       ]
     : []

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import type { SummaryItem } from "@/lib/types"
 import BlocksTable from "@/components/BlocksTable"
 import { metrics } from "@/components/Metrics"
 import Null from "@/components/Null"
+import { HidePunctuation } from "@/components/StylePunctuation"
 import Box from "@/components/svgs/box.svg"
 import Clock from "@/components/svgs/clock.svg"
 import DollarSign from "@/components/svgs/dollar-sign.svg"
@@ -62,7 +63,11 @@ export default async function Index() {
           key: "proven-blocks",
           label: "Proven blocks",
           icon: <Box />,
-          value: formatNumber(recentSummary.total_proven_blocks || 0),
+          value: (
+            <HidePunctuation>
+              {formatNumber(recentSummary.total_proven_blocks || 0)}
+            </HidePunctuation>
+          ),
         },
         {
           key: "avg-cost-per-proof",
@@ -72,10 +77,10 @@ export default async function Index() {
             </>
           ),
           icon: <DollarSign />,
-          value: formatUsd(recentSummary.avg_cost_per_proof || 0).replace(
-            /[¢$]/g,
-            ""
-          ),
+          value: formatNumber(recentSummary.avg_cost_per_proof || 0, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }),
         },
         {
           key: "avg-proving-time",
@@ -85,7 +90,11 @@ export default async function Index() {
             </>
           ),
           icon: <Clock />,
-          value: prettyMs(Number(recentSummary.avg_proving_time) || 0),
+          value: (
+            <HidePunctuation>
+              {prettyMs(Number(recentSummary.avg_proving_time) || 0)}
+            </HidePunctuation>
+          ),
         },
       ]
     : []

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,22 +131,28 @@ export default async function Index() {
           Starting by proving 1-of-100 blocks and soon{" "}
           <span className="text-primary">real time proving</span>
         </p>
-        <div className="flex w-full max-w-2xl justify-around">
+        <div className="mx-auto grid w-full max-w-2xl grid-cols-[auto,auto,auto] gap-4">
           {summaryItems.map(({ key, label, icon, value }) => (
-            <div key={key} className="flex flex-col gap-1 p-2">
-              <div className="flex flex-col items-center justify-center gap-x-2 md:flex-row">
+            <div
+              key={key}
+              className="row-span-3 grid grid-rows-subgrid gap-1 p-2"
+            >
+              {/* Row 1 - Metric icon and value */}
+              <div className="col-span-1 row-span-1 flex h-full flex-col items-center justify-center gap-x-2 md:flex-row">
                 <p className="font-mono text-2xl text-primary md:text-3xl lg:text-4xl">
                   {icon}
                 </p>
-                <p className="text-center font-mono text-2xl text-primary md:text-3xl lg:text-4xl">
+                <p className="h-auto text-nowrap text-center font-mono text-2xl text-primary md:text-3xl lg:text-4xl">
                   {value}
                 </p>
               </div>
+              {/* Row 2 - Metric label */}
               <div>
                 <p className="text-center text-xs uppercase md:text-sm">
                   {label}
                 </p>
               </div>
+              {/* Row 3 - Metric time span */}
               <p className="text-center text-xs font-bold uppercase text-body-secondary">
                 Last 30 days
               </p>

--- a/components/StylePunctuation.tsx
+++ b/components/StylePunctuation.tsx
@@ -10,7 +10,7 @@ const StylePunctuation = ({
   className,
 }: StylePunctuationProps): React.ReactNode[] =>
   children.split("").map((char, i) => {
-    if (/[\d\w]/g.test(char)) return char
+    if (/[\d]/g.test(char)) return char
     return (
       <span key={i} className={className}>
         {char}

--- a/components/StylePunctuation.tsx
+++ b/components/StylePunctuation.tsx
@@ -10,7 +10,7 @@ const StylePunctuation = ({
   className,
 }: StylePunctuationProps): React.ReactNode[] =>
   children.split("").map((char, i) => {
-    if (/\d/g.test(char)) return char
+    if (/[\d\w]/g.test(char)) return char
     return (
       <span key={i} className={className}>
         {char}
@@ -25,7 +25,7 @@ type HidePunctuationProps = {
 const HidePunctuation = ({ children }: HidePunctuationProps) => {
   if (children === "-") return <Null />
   return (
-    <StylePunctuation className="invisible select-none text-[8px]">
+    <StylePunctuation className="invisible mx-[-0.15em] select-none">
       {children}
     </StylePunctuation>
   )

--- a/components/ui/metric.tsx
+++ b/components/ui/metric.tsx
@@ -40,7 +40,7 @@ const MetricInfo = React.forwardRef<HTMLDivElement, MetricInfoProps>(
       <PopoverTrigger className="hover:animate-pulse">
         {trigger || (
           <div className="flex items-center gap-2">
-            {label}
+            <span className="line-clamp-1 text-start">{label}</span>
             <InfoCircle className="-mb-0.5 shrink-0" />
           </div>
         )}

--- a/components/ui/metric.tsx
+++ b/components/ui/metric.tsx
@@ -41,7 +41,7 @@ const MetricInfo = React.forwardRef<HTMLDivElement, MetricInfoProps>(
         {trigger || (
           <div className="flex items-center gap-2">
             {label}
-            <InfoCircle className="-mb-0.5" />
+            <InfoCircle className="-mb-0.5 shrink-0" />
           </div>
         )}
       </PopoverTrigger>


### PR DESCRIPTION
## Description
- Fix shrinking info icon on smaller screens
- Fix sizing bugs with the HidePunctuation component
- Update styling for the recent summary numbers
- Refactor a few of the flex/grid layouts to use subgrid
- Line clamp metric labels to one line (trailing ellipsis, info icon remains if too narrow)... cleans up many overflow issues, and user can still tap on this to see the full name in the tooltip
- Flips the proof byte size label and the download button so the label is on top. This aligns the gray with the other labels in the row, so I updated the size to `text-sm` to match

## Preview link
- https://deploy-preview-212--ethproofs.netlify.app/

## Related issue
- Fixes #225 