### PR TITLE
Hide zero proving or queued statuses

### DIFF
--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -204,10 +204,7 @@ export const columns: ColumnDef<Block>[] = [
       return (
         <div className="flex flex-col justify-center text-center">
           <ProofStatus className="mx-auto" proofs={proofs} />
-          <div className="whitespace-nowrap text-xs text-body-secondary">
-            <span className="font-body">
-              <metrics.totalTTP.Label />:
-            </span>{" "}
+          <div className="whitespace-nowrap text-sm text-body-secondary">
             {totalTTPStats?.bestFormatted ?? <Null />}
           </div>
         </div>

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -53,8 +53,8 @@ const ProofStatus = ({
       {...props}
     >
       {allProofs.map(({ length: proofCount }, idx) => {
-        // Hide "proving" or "queued" if there are no proofs in that status
-        if (proofCount === 0 && hideEmpty && idx !== 0) return null
+        // Hide if no proofs for that status
+        if (proofCount === 0 && hideEmpty) return null
         return (
           <div key={ORDERED_STATUSES[idx]} className="flex items-center gap-1">
             <MetricInfo

--- a/components/ProofStatus.tsx
+++ b/components/ProofStatus.tsx
@@ -40,7 +40,7 @@ type ProofStatusProps = React.HTMLAttributes<HTMLDivElement> & {
 const ProofStatus = ({
   proofs,
   className,
-  hideEmpty,
+  hideEmpty = true,
   ...props
 }: ProofStatusProps) => {
   const allProofs: Proof[][] = Array(ORDERED_STATUSES.length)
@@ -53,7 +53,8 @@ const ProofStatus = ({
       {...props}
     >
       {allProofs.map(({ length: proofCount }, idx) => {
-        if (proofCount === 0 && hideEmpty) return null
+        // Hide "proving" or "queued" if there are no proofs in that status
+        if (proofCount === 0 && hideEmpty && idx !== 0) return null
         return (
           <div key={ORDERED_STATUSES[idx]} className="flex items-center gap-1">
             <MetricInfo


### PR DESCRIPTION
## Description
- Hides the `proving` and `queued` proof status counters if they are zero
- Only shows them when they are actively in those statuses
- `proved` status shown always, as soon as any proof has been initialized while it is still `0`
- This left a long `total time to proof: 12m 48s` label beneath the now-narrow status indicators, so I removed this, leaving only the value `12m 48s` directly beneath the counter

cc: @nloureiro for feedback