### PR TITLE
Search only hashes or block numbers

### DIFF
--- a/app/api/blocks/search/route.ts
+++ b/app/api/blocks/search/route.ts
@@ -14,6 +14,11 @@ export async function GET(request: NextRequest) {
     return new Response("query search param is required", { status: 400 })
   }
 
+  // if the query is not a hash or a block number, return null
+  if (!isHash(query) && !Number.isInteger(Number(query))) {
+    return Response.json(null)
+  }
+
   const result = await db
     .select({
       block: blocks,


### PR DESCRIPTION
Return null if the query is not a hash or a block number.