### PR TITLE
fix: incorrect escaping in `matcher` config for Next.js routing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -16,6 +16,6 @@ export const config = {
      * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
      * Feel free to modify this pattern to include more paths.
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    '/((?!_next/static|_next/image|favicon\\.ico|.*\\.(svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }


### PR DESCRIPTION
spotted and fixed a bug in the `matcher` pattern — used double escaping (`\\.`) which broke the regex.
in Next.js `matcher`, a single escape (`\.`) is enough since the string is interpreted directly as a RegExp path, not JS code. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined asset request handling to ensure the consistent and accurate delivery of images and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->