### PR TITLE
V02 mobile menu

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,29 +1,15 @@
 import Link from "next/link"
 import Script from "next/script"
 
-import MobileSearchInput from "@/components/header/MobileSearchInput"
-import ThemeSwitch from "@/components/header/ThemeSwitch"
 import LampEffect from "@/components/LampEffect"
-import { AppSidebar } from "@/components/Sidebar"
+import AppSidebar from "@/components/Sidebar"
 import EthProofsLogo from "@/components/svgs/eth-proofs-logo.svg"
-import GitHub from "@/components/svgs/github.svg"
 import Hamburger from "@/components/svgs/hamburger.svg"
-import Heart from "@/components/svgs/heart.svg"
-import { Button, ButtonLink } from "@/components/ui/button"
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer"
+import { Button } from "@/components/ui/button"
+import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer"
+import { Sidebar } from "@/components/ui/sidebar"
 
 import { cn } from "@/lib/utils"
-
-import { SITE_NAME, SITE_REPO } from "@/lib/constants"
 
 import Providers from "./providers"
 
@@ -72,7 +58,9 @@ export default function RootLayout({
       </head>
       <body className="pb-80">
         <Providers>
-          <AppSidebar />
+          <Sidebar>
+            <AppSidebar />
+          </Sidebar>
 
           <div className="relative flex w-full flex-col gap-16 overflow-x-hidden md:w-[calc(100vw_-_var(--sidebar-width))]">
             <LampEffect />
@@ -112,93 +100,7 @@ export default function RootLayout({
                     </Button>
                   </DrawerTrigger>
                   <DrawerContent>
-                    <DrawerHeader className="space-y-16">
-                      <MobileSearchInput />
-                      <DrawerTitle className="mb-4 flex items-center justify-between gap-4">
-                        <Link href="/" className="ms-4">
-                          <EthProofsLogo />
-                        </Link>
-                        <DrawerClose asChild>
-                          <Button variant="ghost">Close</Button>
-                        </DrawerClose>
-                      </DrawerTitle>
-                      <DrawerDescription className="space-y-12">
-                        <nav>
-                          <ul className="space-y-12 text-center">
-                            <li className="list-none">
-                              <Button variant="ghost" size="lg" asChild>
-                                <Link href="/">Proofs</Link>
-                              </Button>
-                            </li>
-                            <li className="list-none">
-                              <Button variant="ghost" size="lg" asChild>
-                                <Link href="/learn">Learn</Link>
-                              </Button>
-                            </li>
-                          </ul>
-                        </nav>
-                        <div className="flex justify-center">
-                          <ThemeSwitch />
-                        </div>
-                      </DrawerDescription>
-                    </DrawerHeader>
-                    <DrawerFooter>
-                      <nav className="flex justify-center">
-                        <Button variant="ghost" size="lg" asChild>
-                          <Link
-                            href={new URL(
-                              SITE_REPO,
-                              "https://github.com"
-                            ).toString()}
-                          >
-                            <GitHub /> GitHub
-                          </Link>
-                        </Button>
-                      </nav>
-                      <footer className="mx-auto mt-16 flex max-w-prose flex-col items-center">
-                        <ButtonLink
-                          size="lg"
-                          href={new URL(
-                            SITE_REPO,
-                            "https://github.com"
-                          ).toString()}
-                          className="mb-12"
-                        >
-                          <GitHub className="size-6" />
-                          <span>Contribute to {SITE_NAME}</span>
-                        </ButtonLink>
-
-                        <p className="mb-4 text-center">
-                          Built with{" "}
-                          <Heart className="mb-0.5 inline animate-heart-beat text-xl text-primary" />{" "}
-                          by the{" "}
-                          <Link
-                            href="https://ethereum.org"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="hover:text-primary-light"
-                          >
-                            ethereum.org
-                          </Link>{" "}
-                          team
-                        </p>
-                        <p className="text-center text-lg text-primary-light">
-                          Public goods are good
-                        </p>
-
-                        <Link
-                          href={new URL(
-                            SITE_REPO + "/issues/new/choose/",
-                            "https://github.com"
-                          ).toString()}
-                          className="mt-8 text-center text-body-secondary"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          Spot a bug? Report it here
-                        </Link>
-                      </footer>
-                    </DrawerFooter>
+                    <AppSidebar />
                   </DrawerContent>
                 </Drawer>
               </header>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -18,7 +18,6 @@ import SearchInput from "./header/SearchInput"
 import ThemeSwitch from "./header/ThemeSwitch"
 import Link from "./ui/link"
 import {
-  Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
@@ -29,141 +28,141 @@ import {
 } from "./ui/sidebar"
 import { Skeleton } from "./ui/skeleton"
 
-export function AppSidebar() {
-  return (
-    <Sidebar>
-      <SidebarHeader className="mb-4 mt-11 space-y-10 px-6">
-        <div className="flex items-end justify-between gap-4">
-          <Link href="/">
-            <EthProofsLogo className="text-[2.625rem] text-body" />
-          </Link>
+const AppSidebar = () => (
+  <>
+    <SidebarHeader className="mb-4 mt-11 space-y-10 px-6">
+      <div className="flex items-end justify-between gap-4">
+        <Link href="/">
+          <EthProofsLogo className="text-[2.625rem] text-body" />
+        </Link>
 
-          <Suspense fallback={<Skeleton className="h-8 w-12 rounded-full" />}>
-            <ThemeSwitch />
-          </Suspense>
-        </div>
-        <SearchInput className="max-md:hidden" placeholder="Search by block" />
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarMenu className="gap-y-10 p-6">
-          <SidebarGroup className="">
-            <SidebarGroupLabel className="">Home</SidebarGroupLabel>
-            <SidebarMenuItem>
-              <Link
-                href="/"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <TrendUpChart />
-                dashboard
-              </Link>
-            </SidebarMenuItem>
-          </SidebarGroup>
-          <SidebarGroup>
-            <SidebarGroupLabel>Explore</SidebarGroupLabel>
-            <SidebarMenuItem>
-              <Link
-                href="/zkvms"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <LightningBolt />
-                zkVMs
-              </Link>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <Link
-                href="/teams"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <ProofCheck />
-                provers
-              </Link>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <Link
-                href="/blocks"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <Box strokeWidth="1" />
-                blocks
-              </Link>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <Link
-                href="/killers"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <Bomb />
-                killers
-              </Link>
-            </SidebarMenuItem>
-          </SidebarGroup>
-          <SidebarGroup>
-            <SidebarGroupLabel>Learn</SidebarGroupLabel>
-            <SidebarMenuItem>
-              <Link
-                href="/learn"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <Document />
-                learn
-              </Link>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <Link
-                href="/api.html"
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-              >
-                <HexTarget />
-                API
-              </Link>
-            </SidebarMenuItem>
-          </SidebarGroup>
-          <SidebarGroup>
-            <SidebarGroupLabel>Contribute</SidebarGroupLabel>
-            <SidebarMenuItem>
-              <Link
-                href={new URL(SITE_REPO, "https://github.com").toString()}
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-                hideArrow
-              >
-                <GitHub className="p-1" />
-                build Ethproofs
-              </Link>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <Link
-                href={new URL(
-                  SITE_REPO + "/issues/new/choose/",
-                  "https://github.com"
-                ).toString()}
-                className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
-                hideArrow
-              >
-                <Bug />
-                spot a bug?
-              </Link>
-            </SidebarMenuItem>
-          </SidebarGroup>
-        </SidebarMenu>
-      </SidebarContent>
-      <SidebarFooter className="mx-auto mb-4 mt-8 flex max-w-prose flex-col items-center space-y-4">
-        <p className="mb-4 text-center">
-          Built with{" "}
-          <Heart className="mb-0.5 inline animate-heart-beat text-xl text-primary" />{" "}
-          by the{" "}
-          <Link
-            href="https://ethereum.org"
-            hideArrow
-            className="hover:text-primary-light"
-          >
-            ethereum.org
-          </Link>{" "}
-          team
-        </p>
-        <p className="text-center text-lg text-primary">
-          Public goods are good
-        </p>
-      </SidebarFooter>
-    </Sidebar>
-  )
-}
+        <Suspense fallback={<Skeleton className="h-8 w-12 rounded-full" />}>
+          <ThemeSwitch />
+        </Suspense>
+      </div>
+      <SearchInput className="max-md:hidden" placeholder="Search by block" />
+    </SidebarHeader>
+    <SidebarContent>
+      <SidebarMenu className="gap-y-10 p-6">
+        <SidebarGroup className="">
+          <SidebarGroupLabel className="">Home</SidebarGroupLabel>
+          <SidebarMenuItem>
+            <Link
+              href="/"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <TrendUpChart />
+              dashboard
+            </Link>
+          </SidebarMenuItem>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Explore</SidebarGroupLabel>
+          <SidebarMenuItem>
+            <Link
+              href="/zkvms"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <LightningBolt />
+              zkVMs
+            </Link>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <Link
+              href="/teams"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <ProofCheck />
+              provers
+            </Link>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <Link
+              href="/blocks"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <Box strokeWidth="1" />
+              blocks
+            </Link>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <Link
+              href="/killers"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <Bomb />
+              killers
+            </Link>
+          </SidebarMenuItem>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Learn</SidebarGroupLabel>
+          <SidebarMenuItem>
+            <Link
+              href="/learn"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <Document />
+              learn
+            </Link>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <Link
+              href="/api.html"
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+            >
+              <HexTarget />
+              API
+            </Link>
+          </SidebarMenuItem>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Contribute</SidebarGroupLabel>
+          <SidebarMenuItem>
+            <Link
+              href={new URL(SITE_REPO, "https://github.com").toString()}
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+              hideArrow
+            >
+              <GitHub className="p-1" />
+              build Ethproofs
+            </Link>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <Link
+              href={new URL(
+                SITE_REPO + "/issues/new/choose/",
+                "https://github.com"
+              ).toString()}
+              className="inline-flex text-body hover:text-primary [&>svg:first-child]:me-2 [&>svg:first-child]:size-6"
+              hideArrow
+            >
+              <Bug />
+              spot a bug?
+            </Link>
+          </SidebarMenuItem>
+        </SidebarGroup>
+      </SidebarMenu>
+    </SidebarContent>
+    <SidebarFooter className="mx-auto mb-4 mt-8 flex max-w-prose flex-col items-center space-y-4">
+      <p className="mb-4 text-center">
+        Built with{" "}
+        <Heart className="mb-0.5 inline animate-heart-beat text-xl text-primary" />{" "}
+        by the{" "}
+        <Link
+          href="https://ethereum.org"
+          hideArrow
+          className="hover:text-primary-light"
+        >
+          ethereum.org
+        </Link>{" "}
+        team
+      </p>
+      <p className="text-center text-lg text-primary">Public goods are good</p>
+    </SidebarFooter>
+  </>
+)
+
+AppSidebar.displayName = "AppSidebar"
+
+export default AppSidebar


### PR DESCRIPTION
Re-use sidebar contents inside mobile menu drawer

Collapsible by tapping open space or sliding drawer off screen. Ideally we can add a close button but this was a quick start to reuse everything for mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced detailed pages for blocks, clusters, teams, and zkVMs, each displaying comprehensive statistics, metrics, and interactive visualizations.
  - Added advanced filtering and tabbed navigation for blocks, clusters, and teams, including multi-machine and single-machine distinctions.
  - Implemented new visual components: KPIs, cluster accordions, hardware grids, pizza charts, line charts, and level meters.
  - Added daily proof statistics and trend charts for cost and latency.
  - Enhanced search, navigation, and sidebar UI with improved accessibility and theming.

- **Bug Fixes**
  - Corrected and unified navigation routes and links throughout the application.

- **Documentation**
  - Improved inline documentation and tooltips for metrics and visualizations.

- **Style**
  - Refined color palette, font weights, and layout for better readability and consistency.
  - Updated card, sidebar, and tab styles for a modern, cohesive look.

- **Chores**
  - Added and updated dependencies for new UI primitives and charting libraries.
  - Introduced new database migrations for supporting advanced metrics and statistics.

- **Refactor**
  - Simplified and modularized page components for maintainability and performance.
  - Centralized and extended type definitions for metrics, statistics, and UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->