### PR TITLE
Fix ring color in tabs content

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "focus-visible:ring-ring mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-border focus-visible:ring-offset-2",
       className
     )}
     {...props}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the focus-visible ring color for tab content to use the primary border color, providing a refreshed visual appearance when navigating with the keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->