### PR TITLE
Fix machine details data

### DIFF
--- a/components/ClusterMachineSummary.tsx
+++ b/components/ClusterMachineSummary.tsx
@@ -2,6 +2,8 @@ import { ClusterMachineBase, MachineBase } from "@/lib/types"
 
 import { cn, sumArray } from "@/lib/utils"
 
+import { getMachineTotalGpuMemory } from "@/lib/machines"
+
 type ClusterMachineSummaryProps = React.HTMLAttributes<HTMLDivElement> & {
   machines: (ClusterMachineBase & {
     machine: MachineBase
@@ -39,7 +41,7 @@ const ClusterMachineSummary = ({
         <span className="block font-mono text-xl text-body">
           {sumArray(
             machines.map(
-              (m) => sumArray(m.machine.gpu_memory_gb) * m.machine_count
+              (m) => getMachineTotalGpuMemory(m.machine) * m.machine_count
             )
           )}{" "}
           GB

--- a/components/HardwareGrid/index.tsx
+++ b/components/HardwareGrid/index.tsx
@@ -15,15 +15,6 @@ type HardwareGridProps = React.ComponentProps<"div"> & {
 }
 
 const HardwareGrid = ({ clusterMachines, className }: HardwareGridProps) => {
-  const totalGpuCount = useMemo(
-    () =>
-      clusterMachines.reduce(
-        (acc, curr) => acc + sumArray(curr.machine.gpu_count),
-        0
-      ),
-    [clusterMachines]
-  )
-
   const totalMachineCount = useMemo(
     () => clusterMachines.reduce((acc, curr) => acc + curr.machine_count, 0),
     [clusterMachines]
@@ -39,10 +30,12 @@ const HardwareGrid = ({ clusterMachines, className }: HardwareGridProps) => {
         // Create array of indices for the count of this machine type
         [...Array(clusterMachine.machine_count)].map((_, countIdx) => {
           const uniqueKey = `machine-${clusterMachine.id}-${countIdx}`
+          const gpuCount = sumArray(clusterMachine.machine.gpu_count)
+
           return (
             <MachineBox
               key={uniqueKey}
-              className={getBoxColor(totalGpuCount)}
+              className={getBoxColor(gpuCount)}
               machine={clusterMachine.machine}
             />
           )

--- a/components/ui/MachineDetails.tsx
+++ b/components/ui/MachineDetails.tsx
@@ -26,24 +26,29 @@ const MachineDetails = ({
         </div>
       </div>
       <div className="flex flex-col gap-y-3">
-        {machine.gpu_models?.map((gpuModel) => (
-          <div key={gpuModel}>
-            <div className="text-center font-mono text-lg text-primary">
-              {gpuModel}
-            </div>
+        {machine.gpu_models?.map((gpuModel, index) => {
+          const gpuCount = machine.gpu_count?.[index] || 0
+          const gpuMemory = machine.gpu_memory_gb?.[index] || 0
 
-            <div className="flex gap-x-3 text-center text-sm">
-              <div className="flex flex-1 flex-col items-center p-2">
-                <div className="text-nowrap text-body-secondary">GPUs</div>
-                <div className="">{sumArray(machine.gpu_count)}</div>
+          return (
+            <div key={gpuModel}>
+              <div className="text-center font-mono text-lg text-primary">
+                {gpuModel}
               </div>
-              <div className="flex flex-1 flex-col items-center p-2">
-                <div className="text-nowrap text-body-secondary">GPU RAM</div>
-                <div className="">{sumArray(machine.gpu_memory_gb)} GB</div>
+
+              <div className="flex gap-x-3 text-center text-sm">
+                <div className="flex flex-1 flex-col items-center p-2">
+                  <div className="text-nowrap text-body-secondary">GPUs</div>
+                  <div>{gpuCount}</div>
+                </div>
+                <div className="flex flex-1 flex-col items-center p-2">
+                  <div className="text-nowrap text-body-secondary">GPU RAM</div>
+                  <div className="">{gpuMemory * gpuCount} GB</div>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   </div>

--- a/lib/machines.ts
+++ b/lib/machines.ts
@@ -1,0 +1,12 @@
+import { MachineBase } from "./types"
+import { sumArray } from "./utils"
+
+export const getMachineTotalGpuMemory = (machine: MachineBase) => {
+  return sumArray(
+    machine.gpu_models?.map((_, index) => {
+      const gpuCount = machine.gpu_count?.[index] || 0
+      const gpuMemory = machine.gpu_memory_gb?.[index] || 0
+      return gpuMemory * gpuCount
+    })
+  )
+}


### PR DESCRIPTION
Uses indexed values for gpu count and memory to display individual GPU information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved GPU details display for machines, now showing GPU count and GPU RAM per GPU model side-by-side.
- **Enhancements**
  - GPU memory summaries are now calculated using a more accurate method for total GPU RAM.
- **Bug Fixes**
  - Corrected the display of GPU counts to show values specific to each GPU model instead of a total sum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->