### PR TITLE
V02 feat: hide machine grid for single machine cluster

### DIFF
--- a/components/ClusterAccordion.tsx
+++ b/components/ClusterAccordion.tsx
@@ -13,7 +13,7 @@ import type {
   ZkvmVersion,
 } from "@/lib/types"
 
-import { cn } from "@/lib/utils"
+import { cn, sumArray } from "@/lib/utils"
 
 import { getBoxIndexColor } from "./HardwareGrid/utils"
 import {
@@ -29,7 +29,7 @@ import ClusterMachineSummary from "./ClusterMachineSummary"
 import HardwareGrid from "./HardwareGrid"
 import Null from "./Null"
 
-import { hasPhysicalMachines } from "@/lib/clusters"
+import { hasPhysicalMachines, isMultiMachineCluster } from "@/lib/clusters"
 import { formatShortDate } from "@/lib/date"
 import { formatUsd } from "@/lib/number"
 import { prettyMs } from "@/lib/time"
@@ -66,6 +66,8 @@ const ClusterAccordionItem = ({
   const hasPhysicalMachinesInCluster = hasPhysicalMachines(
     lastVersion.cluster_machines
   )
+
+  const isMultiMachine = isMultiMachineCluster(lastVersion.cluster_machines)
 
   return (
     <AccordionItem
@@ -133,26 +135,28 @@ const ClusterAccordionItem = ({
           <div className="flex items-center gap-x-20">
             <ClusterMachineSummary machines={lastVersion.cluster_machines} />
 
-            <div className="flex flex-1 flex-col space-y-4 overflow-x-hidden">
-              <HardwareGrid clusterMachines={lastVersion.cluster_machines} />
-              <div className="flex items-center gap-3 self-end">
-                <span className="me-4">GPUs</span>
-                {Array(6)
-                  .fill(0)
-                  .map((_, i) => (
-                    <Fragment key={i}>
-                      <span className="-me-1">{2 ** i}</span>
-                      <div
-                        key={i}
-                        className={cn(
-                          "size-4 rounded-[4px]",
-                          getBoxIndexColor(i)
-                        )}
-                      />
-                    </Fragment>
-                  ))}
+            {isMultiMachine && (
+              <div className="flex flex-1 flex-col space-y-4 overflow-x-hidden">
+                <HardwareGrid clusterMachines={lastVersion.cluster_machines} />
+                <div className="flex items-center gap-3 self-end">
+                  <span className="me-4">GPUs</span>
+                  {Array(6)
+                    .fill(0)
+                    .map((_, i) => (
+                      <Fragment key={i}>
+                        <span className="-me-1">{2 ** i}</span>
+                        <div
+                          key={i}
+                          className={cn(
+                            "size-4 rounded-[4px]",
+                            getBoxIndexColor(i)
+                          )}
+                        />
+                      </Fragment>
+                    ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         ) : (
           <div className="flex min-h-[80px] items-center justify-center italic text-body-secondary">

--- a/components/ClusterMachineSummary.tsx
+++ b/components/ClusterMachineSummary.tsx
@@ -2,6 +2,7 @@ import { ClusterMachineBase, MachineBase } from "@/lib/types"
 
 import { cn, sumArray } from "@/lib/utils"
 
+import { isMultiMachineCluster } from "@/lib/clusters"
 import { getMachineTotalGpuMemory } from "@/lib/machines"
 
 type ClusterMachineSummaryProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -14,61 +15,77 @@ const ClusterMachineSummary = ({
   machines,
   className,
   ...props
-}: ClusterMachineSummaryProps) => (
-  <div
-    className={cn("flex flex-col items-center gap-y-6 text-center", className)}
-    {...props}
-  >
-    <div className="flex w-fit flex-col items-center text-nowrap px-2 text-center">
-      <span className="block text-nowrap text-sm text-body-secondary">
-        total machines
-      </span>
-      <span className="block font-mono text-2xl font-bold text-body">
-        {sumArray(machines.map((m) => m.machine_count))}
-      </span>
+}: ClusterMachineSummaryProps) => {
+  const isMultiMachine = isMultiMachineCluster(machines)
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center gap-y-6 text-center",
+        !isMultiMachine && "w-full",
+        className
+      )}
+      {...props}
+    >
+      {isMultiMachine && (
+        <div className="flex w-fit flex-col items-center text-nowrap px-2 text-center">
+          <span className="block text-nowrap text-sm text-body-secondary">
+            total machines
+          </span>
+          <span className="block font-mono text-2xl font-bold text-body">
+            {sumArray(machines.map((m) => m.machine_count))}
+          </span>
+        </div>
+      )}
+      <div
+        className={cn(
+          "flex w-full justify-around gap-x-3 gap-y-4 text-center",
+          isMultiMachine && "grid grid-cols-2 place-items-center"
+        )}
+      >
+        <div className="flex w-full flex-col items-center text-nowrap text-center">
+          <span className="block text-sm text-body-secondary">GPUs</span>
+          <span className="block font-mono text-xl text-body">
+            {sumArray(
+              machines.map(
+                (m) => sumArray(m.machine.gpu_count) * m.machine_count
+              )
+            )}
+          </span>
+        </div>
+        <div className="flex w-full flex-col items-center text-nowrap text-center">
+          <span className="block text-sm text-body-secondary">GPU RAM</span>
+          <span className="block font-mono text-xl text-body">
+            {sumArray(
+              machines.map(
+                (m) => getMachineTotalGpuMemory(m.machine) * m.machine_count
+              )
+            )}{" "}
+            GB
+          </span>
+        </div>
+        <div className="flex w-full flex-col items-center text-nowrap text-center">
+          <span className="block text-sm text-body-secondary">CPU cores</span>
+          <span className="block font-mono text-xl text-body">
+            {sumArray(
+              machines.map((m) => (m.machine.cpu_cores ?? 0) * m.machine_count)
+            )}
+          </span>
+        </div>
+        <div className="flex w-full flex-col items-center text-nowrap text-center">
+          <span className="block text-sm text-body-secondary">CPU RAM</span>
+          <span className="block font-mono text-xl text-body">
+            {sumArray(
+              machines.map(
+                (m) => sumArray(m.machine.memory_size_gb) * m.machine_count
+              )
+            )}{" "}
+            GB
+          </span>
+        </div>
+      </div>
     </div>
-    <div className="grid grid-cols-2 place-items-center gap-x-3 gap-y-4 text-center">
-      <div className="flex w-full flex-col items-center text-nowrap text-center">
-        <span className="block text-sm text-body-secondary">GPUs</span>
-        <span className="block font-mono text-xl text-body">
-          {sumArray(
-            machines.map((m) => sumArray(m.machine.gpu_count) * m.machine_count)
-          )}
-        </span>
-      </div>
-      <div className="flex w-full flex-col items-center text-nowrap text-center">
-        <span className="block text-sm text-body-secondary">GPU RAM</span>
-        <span className="block font-mono text-xl text-body">
-          {sumArray(
-            machines.map(
-              (m) => getMachineTotalGpuMemory(m.machine) * m.machine_count
-            )
-          )}{" "}
-          GB
-        </span>
-      </div>
-      <div className="flex flex-col items-center text-nowrap text-center">
-        <span className="block text-sm text-body-secondary">CPU cores</span>
-        <span className="block font-mono text-xl text-body">
-          {sumArray(
-            machines.map((m) => (m.machine.cpu_cores ?? 0) * m.machine_count)
-          )}
-        </span>
-      </div>
-      <div className="flex flex-col items-center text-nowrap text-center">
-        <span className="block text-sm text-body-secondary">CPU RAM</span>
-        <span className="block font-mono text-xl text-body">
-          {sumArray(
-            machines.map(
-              (m) => sumArray(m.machine.memory_size_gb) * m.machine_count
-            )
-          )}{" "}
-          GB
-        </span>
-      </div>
-    </div>
-  </div>
-)
+  )
+}
 
 ClusterMachineSummary.displayName = "ClusterMachineSummary"
 

--- a/lib/clusters.ts
+++ b/lib/clusters.ts
@@ -1,5 +1,14 @@
-import { ClusterMachineBase } from "./types"
+import type { ClusterMachineBase, MachineBase } from "./types"
 
 export const hasPhysicalMachines = (clusterMachines: ClusterMachineBase[]) => {
   return clusterMachines.some((cm) => cm.machine_id !== null)
+}
+
+export const isMultiMachineCluster = (
+  clusterMachines: ClusterMachineBase[]
+) => {
+  return (
+    clusterMachines.length > 1 ||
+    clusterMachines.some((config) => config.machine_count > 1)
+  )
 }

--- a/lib/machines.ts
+++ b/lib/machines.ts
@@ -1,4 +1,4 @@
-import { MachineBase } from "./types"
+import type { MachineBase } from "./types"
 import { sumArray } from "./utils"
 
 export const getMachineTotalGpuMemory = (machine: MachineBase) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hardware grid and GPU legend are now shown only for multi-machine clusters, improving clarity in cluster details.
  - "Total machines" summary appears only for multi-machine clusters.

- **Refactor**
  - Improved layout and conditional rendering in cluster summary components for a more adaptive and streamlined presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->