### PR TITLE
fix: cluster naming and link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next"
 
 import ProofsStats from "@/components/ProofsStats"
 import BlocksSection from "@/components/sections/BlocksSection"
-import ProverTeamsSection from "@/components/sections/ProvingTeamsSection"
+import ClustersSection from "@/components/sections/ClustersSection"
 import ZkvmsSection from "@/components/sections/ZkvmsSection"
 
 import { getRecentSummary } from "@/lib/api/stats"
@@ -34,7 +34,7 @@ export default async function Index() {
 
         <section id="provers">
           <Suspense fallback={null}>
-            <ProverTeamsSection />
+            <ClustersSection />
           </Suspense>
         </section>
 

--- a/components/sections/ClustersSection.tsx
+++ b/components/sections/ClustersSection.tsx
@@ -9,7 +9,7 @@ import { Card, CardHeader, CardTitle } from "../ui/card"
 import { getActiveClusters, getActiveMachineCount } from "@/lib/api/clusters"
 import { getClusterSummary, getTeamsSummary } from "@/lib/api/stats"
 
-const ProverTeamsSection = async () => {
+const ClustersSection = async () => {
   const [teamsSummary, clusterSummary, machineCount, activeClusters] =
     await Promise.all([
       getTeamsSummary(),
@@ -18,7 +18,7 @@ const ProverTeamsSection = async () => {
       getActiveClusters(),
     ])
 
-  const proversSummary: SummaryItem[] = [
+  const clustersSummary: SummaryItem[] = [
     {
       key: "teams",
       label: "teams",
@@ -59,7 +59,7 @@ const ProverTeamsSection = async () => {
         </CardTitle>
 
         <div className="py-4">
-          <KPIs items={proversSummary} />
+          <KPIs items={clustersSummary} />
         </div>
       </CardHeader>
 
@@ -69,7 +69,7 @@ const ProverTeamsSection = async () => {
       />
 
       <div className="flex justify-center">
-        <ButtonLink variant="outline" href="/teams">
+        <ButtonLink variant="outline" href="/clusters">
           See all
         </ButtonLink>
       </div>
@@ -77,4 +77,4 @@ const ProverTeamsSection = async () => {
   )
 }
 
-export default ProverTeamsSection
+export default ClustersSection


### PR DESCRIPTION
- Filename `ProvingTeamsSection.tsx` -> `ClustersSection.tsx`
- Component name `ProverTeamsSection` -> `ClustersSection`
- Fix link in clusters section from `/teams` to `/clusters`
- List name `proversSummary` -> `clustersSummary`
