### PR TITLE
Fix: handle block race condition error

### DIFF
--- a/app/api/v0/proofs/proved/route.ts
+++ b/app/api/v0/proofs/proved/route.ts
@@ -63,13 +63,16 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     try {
       // create block
       console.log("creating block", block_number)
-      await db.insert(blocks).values({
-        block_number,
-        gas_used: Number(blockData.gasUsed),
-        transaction_count: blockData.txsCount,
-        timestamp: new Date(Number(blockData.timestamp) * 1000).toISOString(),
-        hash: blockData.hash,
-      })
+      await db
+        .insert(blocks)
+        .values({
+          block_number,
+          gas_used: Number(blockData.gasUsed),
+          transaction_count: blockData.txsCount,
+          timestamp: new Date(Number(blockData.timestamp) * 1000).toISOString(),
+          hash: blockData.hash,
+        })
+        .onConflictDoNothing()
     } catch (error) {
       console.error("error creating block", error)
       return new Response("Internal server error", { status: 500 })

--- a/app/api/v0/proofs/proving/route.ts
+++ b/app/api/v0/proofs/proving/route.ts
@@ -59,13 +59,16 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     try {
       // create block
       console.log("creating block", block_number)
-      await db.insert(blocks).values({
-        block_number,
-        gas_used: Number(blockData.gasUsed),
-        transaction_count: blockData.txsCount,
-        timestamp: new Date(Number(blockData.timestamp) * 1000).toISOString(),
-        hash: blockData.hash,
-      })
+      await db
+        .insert(blocks)
+        .values({
+          block_number,
+          gas_used: Number(blockData.gasUsed),
+          transaction_count: blockData.txsCount,
+          timestamp: new Date(Number(blockData.timestamp) * 1000).toISOString(),
+          hash: blockData.hash,
+        })
+        .onConflictDoNothing()
     } catch (error) {
       console.error("error creating block", error)
       return new Response("Internal server error", { status: 500 })

--- a/app/api/v0/proofs/queued/route.ts
+++ b/app/api/v0/proofs/queued/route.ts
@@ -59,13 +59,16 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     try {
       // create block
       console.log("creating block", block_number)
-      await db.insert(blocks).values({
-        block_number,
-        gas_used: Number(blockData.gasUsed),
-        transaction_count: blockData.txsCount,
-        timestamp: new Date(Number(blockData.timestamp) * 1000).toISOString(),
-        hash: blockData.hash,
-      })
+      await db
+        .insert(blocks)
+        .values({
+          block_number,
+          gas_used: Number(blockData.gasUsed),
+          transaction_count: blockData.txsCount,
+          timestamp: new Date(Number(blockData.timestamp) * 1000).toISOString(),
+          hash: blockData.hash,
+        })
+        .onConflictDoNothing()
     } catch (error) {
       console.error("error creating block", error)
       return new Response("Internal server error", { status: 500 })


### PR DESCRIPTION
There's a race condition where multiple requests might try to insert the same block simultaneously.

This PR handles it gracefully with `onConflictDoNothing` (as it is expected) instead of returning a 500 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved database reliability by preventing errors caused by duplicate block entries during insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->