### PR TITLE
Fix download all

### DIFF
--- a/app/api/v0/proofs/download/all/[block]/route.ts
+++ b/app/api/v0/proofs/download/all/[block]/route.ts
@@ -51,13 +51,14 @@ export async function GET(
       cycle_type,
     } = proofRow.cluster_version.cluster
     const teamName = team?.name ? team.name : cluster_id.split("-")[0]
-    const filename = `block_${block}_${proof_type}_${cycle_type}_${teamName}.txt`
+    const filenameInStorage = `${proofRow.block_number}_${teamName}_${proofRow.proof_id}.txt`
 
-    const blob = await downloadProofBinary(filename)
+    const blob = await downloadProofBinary(filenameInStorage)
     if (blob) {
       const arrayBuffer = await blob.arrayBuffer()
       const binaryBuffer = Buffer.from(arrayBuffer)
 
+      const filename = `block_${block}_${proof_type}_${cycle_type}_${teamName}.txt`
       binaryBuffers.push({ binaryBuffer, filename })
     }
   }


### PR DESCRIPTION
Matches the binary filename in storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured downloaded proof files in zip archives retain their original descriptive filenames, while fetching files using storage-specific names. This improves clarity and consistency for users when accessing downloaded proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->