### PR TITLE
Fix: enable dynamic routing for cloud instances API

### DIFF
--- a/app/api/v0/cloud-instances/route.ts
+++ b/app/api/v0/cloud-instances/route.ts
@@ -3,6 +3,8 @@ import { z } from "zod"
 import { getInstances } from "@/lib/api/cloud-instances"
 import { CloudInstancesQuerySchema } from "@/lib/zod/schemas/cloud-instance"
 
+export const dynamic = "force-dynamic"
+
 export const GET = async (request: Request) => {
   try {
     const { searchParams } = new URL(request.url)


### PR DESCRIPTION
Current error:

```
11:03:44 AM: error fetching cloud instances B [Error]: Dynamic server usage: Route /api/v0/cloud-instances couldn't be rendered statically because it used `request.url`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error
    at V (/opt/build/repo/node_modules/.pnpm/next@14.2.28_@babel+core@7.26.10_react-
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to improve handling of dynamic content for cloud instances API. No changes to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->