### PR TITLE
feat: cluster info restructure

### DIFF
--- a/components/ClusterAccordion.tsx
+++ b/components/ClusterAccordion.tsx
@@ -78,18 +78,29 @@ const ClusterAccordionItem = ({
     >
       <div className="col-span-6 grid grid-cols-subgrid items-center gap-12 px-6 py-4 hover:bg-primary/5 dark:hover:bg-primary/10">
         <div className="col-start-1 flex flex-col gap-1">
-          <DisplayTeamLink team={clusterDetails.team} />
-          <div>
-            <span className="text-sm text-primary">
-              <Link
-                href={`/zkvms/${lastVersion.zkvm_version.zkvm.slug}`}
-                className="hover:underline"
-              >
-                {lastVersion.zkvm_version.zkvm.name}
-              </Link>{" "}
-              |{" "}
-            </span>
-            <span className="text-sm">{clusterDetails.nickname}</span>
+          <Link
+            href={`/clusters/${clusterDetails.id}`}
+            className="text-xl text-primary hover:underline"
+          >
+            {clusterDetails.nickname}
+          </Link>
+          <div className="flex items-center gap-2 text-sm">
+            <Link
+              href={`/zkvms/${lastVersion.zkvm_version.zkvm.slug}`}
+              className="block hover:underline"
+            >
+              {lastVersion.zkvm_version.zkvm.name}
+            </Link>{" "}
+            <span className="font-mono text-sm italic text-body-secondary">
+              by
+            </span>{" "}
+            <div className="min-w-24">
+              <DisplayTeamLink
+                team={clusterDetails.team}
+                className="block"
+                height={14}
+              />
+            </div>
           </div>
         </div>
         <div className="col-start-2 flex justify-center">

--- a/components/ClusterAccordion.tsx
+++ b/components/ClusterAccordion.tsx
@@ -80,14 +80,14 @@ const ClusterAccordionItem = ({
         <div className="col-start-1 flex flex-col gap-1">
           <Link
             href={`/clusters/${clusterDetails.id}`}
-            className="text-xl text-primary hover:underline"
+            className="text-xl text-primary hover:text-primary-light hover:underline"
           >
             {clusterDetails.nickname}
           </Link>
           <div className="flex items-center gap-2 text-sm">
             <Link
               href={`/zkvms/${lastVersion.zkvm_version.zkvm.slug}`}
-              className="block hover:underline"
+              className="block hover:text-primary-light hover:underline"
             >
               {lastVersion.zkvm_version.zkvm.name}
             </Link>{" "}

--- a/components/SoftwareAccordion.tsx
+++ b/components/SoftwareAccordion.tsx
@@ -41,7 +41,7 @@ const SoftwareAccordionItem = ({
         <div className="col-start-1 flex items-center gap-3">
           <Link
             href={`/zkvms/${zkvm.slug}`}
-            className="block text-2xl text-primary hover:underline"
+            className="block text-2xl text-primary hover:text-primary-light hover:underline"
           >
             {zkvm.name}
           </Link>


### PR DESCRIPTION
- Rearrange the starting element of the cluster list item
- Moved cluster nickname to primary position, and wrapped in Link to cluster details page, styling with primary color, `mono` font, size bump. This matches the pattern of how we present these items in the other accordions.
- Second line follows `[<zkvm>](/zkvms/<slug>] by [<team-logo>](/teams/<teamId>)` pattern used in zkVM section above, using regular body text color (with underline on hover if text link)

https://github.com/user-attachments/assets/2f68610a-3e4c-4158-b188-8a5ba108c461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the visual hierarchy and layout of the cluster header in the accordion, making the cluster nickname more prominent and enhancing the grouping of related information.
  - Enhanced link hover styling in the software accordion to include a lighter primary color, improving visual feedback for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->