### PR TITLE
cache granularity

### DIFF
--- a/app/api/v0/proofs/proved/route.ts
+++ b/app/api/v0/proofs/proved/route.ts
@@ -1,5 +1,4 @@
-import { eq, sql } from "drizzle-orm"
-import { revalidatePath } from "next/cache"
+import { revalidateTag } from "next/cache"
 import { ZodError } from "zod"
 
 import { db } from "@/db"
@@ -189,8 +188,9 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
       return newProof
     })
 
-    // invalidate home page cache
-    revalidatePath("/")
+    // invalidate cache
+    revalidateTag("proofs")
+    revalidateTag("blocks")
 
     // return the generated proof_id
     return Response.json(newProof)

--- a/app/api/v0/proofs/proving/route.ts
+++ b/app/api/v0/proofs/proving/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from "next/cache"
+import { revalidateTag } from "next/cache"
 import { ZodError } from "zod"
 
 import { db } from "@/db"
@@ -129,8 +129,9 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
       })
       .returning({ proof_id: proofs.proof_id })
 
-    // invalidate home page cache
-    revalidatePath("/")
+    // invalidate cache
+    revalidateTag("proofs")
+    revalidateTag("blocks")
 
     // return the generated proof_id
     return Response.json(proof)

--- a/app/api/v0/proofs/queued/route.ts
+++ b/app/api/v0/proofs/queued/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from "next/cache"
+import { revalidateTag } from "next/cache"
 import { ZodError } from "zod"
 
 import { db } from "@/db"
@@ -129,8 +129,8 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
       })
       .returning({ proof_id: proofs.proof_id })
 
-    // invalidate home page cache
-    revalidatePath("/")
+    // invalidate cache
+    revalidateTag("blocks")
 
     // return the generated proof_id
     return Response.json(proof)

--- a/components/SimpleBlockTable.tsx
+++ b/components/SimpleBlockTable.tsx
@@ -1,7 +1,7 @@
 import { columns } from "./BlocksTable/columns"
 import DataTableUncontrolled from "./ui/data-table-uncontrolled"
 
-import { fetchBlocksPaginated, MachineType } from "@/lib/api/blocks"
+import { fetchBlocks, MachineType } from "@/lib/api/blocks"
 import { getTeams } from "@/lib/api/teams"
 import { mergeBlocksWithTeams } from "@/lib/blocks"
 
@@ -12,12 +12,9 @@ type Props = {
 
 const SimpleBlocksTable = async ({ className, machineType }: Props) => {
   const teams = await getTeams()
-  const blocks = await fetchBlocksPaginated(
-    { pageIndex: 0, pageSize: 5 },
-    machineType
-  )
+  const blocks = await fetchBlocks(machineType, 5)
 
-  const blocksWithTeams = mergeBlocksWithTeams(blocks.rows, teams)
+  const blocksWithTeams = mergeBlocksWithTeams(blocks, teams)
 
   return (
     <DataTableUncontrolled

--- a/components/sections/ClustersSection.tsx
+++ b/components/sections/ClustersSection.tsx
@@ -7,12 +7,13 @@ import { ButtonLink } from "../ui/button"
 import { Card, CardHeader, CardTitle } from "../ui/card"
 
 import { getActiveClusters, getActiveMachineCount } from "@/lib/api/clusters"
-import { getClusterSummary, getTeamsSummary } from "@/lib/api/stats"
+import { getClusterSummary } from "@/lib/api/stats"
+import { getTeamsCount } from "@/lib/api/teams"
 
 const ClustersSection = async () => {
-  const [teamsSummary, clusterSummary, machineCount, activeClusters] =
+  const [teamsCount, clusterSummary, machineCount, activeClusters] =
     await Promise.all([
-      getTeamsSummary(),
+      getTeamsCount(),
       getClusterSummary(),
       getActiveMachineCount(),
       getActiveClusters(),
@@ -22,7 +23,7 @@ const ClustersSection = async () => {
     {
       key: "teams",
       label: "teams",
-      value: teamsSummary.length,
+      value: teamsCount,
     },
     {
       key: "proving-machines",

--- a/lib/api/blocks.ts
+++ b/lib/api/blocks.ts
@@ -118,3 +118,56 @@ export const fetchBlock = cache(
     return block
   }
 )
+
+export const fetchBlocks = cache(
+  async (machineType: MachineType = "all", limit: number = 10) => {
+    const blocksRows = await db.query.blocks.findMany({
+      with: {
+        proofs: {
+          with: {
+            cluster_version: {
+              with: {
+                cluster: true,
+                cluster_machines: {
+                  with: {
+                    cloud_instance: true,
+                    machine: true,
+                  },
+                },
+              },
+            },
+          },
+          // Filter proofs by cluster type
+          where:
+            machineType === "all"
+              ? undefined
+              : (proofs, { exists, eq, and }) =>
+                  exists(
+                    db
+                      .select()
+                      .from(clusterVersions)
+                      .innerJoin(
+                        clusters,
+                        eq(clusterVersions.cluster_id, clusters.id)
+                      )
+                      .where(
+                        and(
+                          eq(clusterVersions.id, proofs.cluster_version_id),
+                          eq(clusters.is_multi_machine, machineType === "multi")
+                        )
+                      )
+                  ),
+        },
+      },
+      orderBy: (blocks, { desc }) => [desc(blocks.block_number)],
+      limit,
+    })
+
+    return blocksRows
+  },
+  ["blocks-top-list"],
+  {
+    revalidate: 60,
+    tags: ["blocks"],
+  }
+)

--- a/lib/api/blocks.ts
+++ b/lib/api/blocks.ts
@@ -167,7 +167,7 @@ export const fetchBlocks = cache(
   },
   ["blocks-top-list"],
   {
-    revalidate: 60,
+    revalidate: 60, // every minute
     tags: ["blocks"],
   }
 )

--- a/lib/api/proofs.ts
+++ b/lib/api/proofs.ts
@@ -72,6 +72,11 @@ export const fetchProofsPerStatusCount = cache(
       .groupBy(proofs.proof_status)
 
     return proofsPerStatusCount
+  },
+  ["proofs-per-status-count"],
+  {
+    revalidate: 60 * 60 * 24, // daily
+    tags: ["proofs"],
   }
 )
 

--- a/lib/api/stats.ts
+++ b/lib/api/stats.ts
@@ -1,5 +1,6 @@
 import { addDays, startOfDay } from "date-fns"
 import { and, asc, eq, notIlike, sql } from "drizzle-orm"
+import { unstable_cache as cache } from "next/cache"
 
 import { db } from "@/db"
 import {
@@ -47,17 +48,31 @@ export const fetchProverDailyStats = async (teamId: string, days: number) => {
   })
 }
 
-export const getRecentSummary = async () => {
-  const [recentSummary] = await db.select().from(recentSummaryView).limit(1)
+export const getRecentSummary = cache(
+  async () => {
+    const [recentSummary] = await db.select().from(recentSummaryView).limit(1)
 
-  return recentSummary
-}
+    return recentSummary
+  },
+  ["recent-summary"],
+  {
+    revalidate: 60 * 60 * 24, // daily
+    tags: ["recent-summary"],
+  }
+)
 
-export const getClusterSummary = async () => {
-  const clusterSummary = await db.select().from(clusterSummaryView)
+export const getClusterSummary = cache(
+  async () => {
+    const clusterSummary = await db.select().from(clusterSummaryView)
 
-  return clusterSummary
-}
+    return clusterSummary
+  },
+  ["cluster-summary"],
+  {
+    revalidate: 60 * 60 * 24, // daily
+    tags: ["cluster-summary"],
+  }
+)
 
 export const getClusterSummaryById = async (id: string) => {
   const [clusterSummary] = await db
@@ -69,26 +84,33 @@ export const getClusterSummaryById = async (id: string) => {
   return clusterSummary
 }
 
-export const getTeamsSummary = async () => {
-  const teamsSummary = await db
-    .select()
-    .from(teamsSummaryView)
-    .innerJoin(teams, eq(teamsSummaryView.team_id, teams.id))
-    // hide test teams from the provers list
-    .where(notIlike(teamsSummaryView.team_name, "%test%"))
-    // sort by avg_proving_time, leave nulls or 0 last
-    .orderBy(
-      asc(
-        sql`CASE WHEN ${teamsSummaryView.avg_proving_time} IS NULL OR ${teamsSummaryView.avg_proving_time} = 0 THEN 1 ELSE 0 END`
-      ),
-      asc(teamsSummaryView.avg_proving_time)
-    )
+export const getTeamsSummary = cache(
+  async () => {
+    const teamsSummary = await db
+      .select()
+      .from(teamsSummaryView)
+      .innerJoin(teams, eq(teamsSummaryView.team_id, teams.id))
+      // hide test teams from the provers list
+      .where(notIlike(teamsSummaryView.team_name, "%test%"))
+      // sort by avg_proving_time, leave nulls or 0 last
+      .orderBy(
+        asc(
+          sql`CASE WHEN ${teamsSummaryView.avg_proving_time} IS NULL OR ${teamsSummaryView.avg_proving_time} = 0 THEN 1 ELSE 0 END`
+        ),
+        asc(teamsSummaryView.avg_proving_time)
+      )
 
-  return teamsSummary.map(({ teams, teams_summary }) => ({
-    ...teams_summary,
-    ...teams,
-  }))
-}
+    return teamsSummary.map(({ teams, teams_summary }) => ({
+      ...teams_summary,
+      ...teams,
+    }))
+  },
+  ["teams-summary"],
+  {
+    revalidate: 60 * 60 * 24, // daily
+    tags: ["teams-summary"],
+  }
+)
 
 export const getTeamSummary = async (teamId: string) => {
   const [teamSummary] = await db

--- a/lib/api/teams.ts
+++ b/lib/api/teams.ts
@@ -1,6 +1,8 @@
+import { count, notIlike } from "drizzle-orm"
 import { unstable_cache as cache } from "next/cache"
 
 import { db } from "@/db"
+import { teams } from "@/db/schema"
 
 export const getTeam = cache(async (id: string) => {
   const team = await db.query.teams.findFirst({
@@ -10,10 +12,17 @@ export const getTeam = cache(async (id: string) => {
   return team
 })
 
-export const getTeams = cache(async () => {
-  const teams = await db.query.teams.findMany()
-  return teams
-})
+export const getTeams = cache(
+  async () => {
+    const teams = await db.query.teams.findMany()
+    return teams
+  },
+  ["teams"],
+  {
+    revalidate: 60 * 60 * 24, // daily
+    tags: ["teams"],
+  }
+)
 
 export const getTeamBySlug = cache(async (slug: string) => {
   const team = await db.query.teams.findFirst({
@@ -21,3 +30,20 @@ export const getTeamBySlug = cache(async (slug: string) => {
   })
   return team
 })
+
+export const getTeamsCount = cache(
+  async () => {
+    const teamsCount = await db
+      .select({ count: count() })
+      .from(teams)
+      // hide test teams from the provers list
+      .where(notIlike(teams.name, "%test%"))
+
+    return teamsCount[0].count
+  },
+  ["teams-count"],
+  {
+    revalidate: 60 * 60 * 24, // daily
+    tags: ["teams"],
+  }
+)


### PR DESCRIPTION
- create custom queries for home page
- set a more granular cache instead of revalidating the whole page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to fetch the count of teams, excluding test teams.
  - Added a new function to fetch a list of blocks with filtering options.

- **Improvements**
  - Enhanced caching strategies for teams, blocks, proofs, and statistics, including daily revalidation and cache tagging for more efficient data updates.
  - Updated components to use new or improved data-fetching methods and structures.

- **Refactor**
  - Switched cache invalidation from path-based to tag-based for better cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->