### PR TITLE
Only vendor teams

### DIFF
--- a/app/teams/[teamId]/page.tsx
+++ b/app/teams/[teamId]/page.tsx
@@ -1,5 +1,4 @@
 import { type Metadata } from "next"
-import Image from "next/image"
 import { notFound } from "next/navigation"
 
 import type { SummaryItem, Team, Zkvm } from "@/lib/types"
@@ -17,17 +16,15 @@ import { HeroBody, HeroItem, HeroItemLabel } from "@/components/ui/hero"
 import Link from "@/components/ui/link"
 import VendorsAside from "@/components/VendorsAside"
 
-import { cn } from "@/lib/utils"
-
 import { SITE_NAME } from "@/lib/constants"
 
 import { getActiveClusters } from "@/lib/api/clusters"
 import { getTeamSummary } from "@/lib/api/stats"
-import { getVendorByUserId } from "@/lib/api/vendor"
+import { getVendor } from "@/lib/api/vendors"
 import { getZkvmsByVendorId } from "@/lib/api/zkvms"
 import { getMetadata } from "@/lib/metadata"
 import { formatUsd } from "@/lib/number"
-import { getTeamByIdOrSlug } from "@/lib/teams"
+import { getTeamByIdOrSlug, getVendorByIdOrSlug } from "@/lib/teams"
 import { prettyMs } from "@/lib/time"
 import { getHost, getTwitterHandle } from "@/lib/url"
 
@@ -57,14 +54,23 @@ export default async function TeamDetailsPage({
   let team: Team | undefined
   try {
     team = await getTeamByIdOrSlug(teamId)
-    if (!team) throw new Error()
+    if (!team) {
+      // if team is not found, try to get vendor
+      // NOTE: edge case for handling only vendor pages
+      // @ts-expect-error expected: vendor does not have `storage_quota_bytes`
+      team = await getVendorByIdOrSlug(teamId)
+    }
+
+    if (!team) {
+      throw new Error()
+    }
   } catch {
     return notFound()
   }
 
   const [teamSummary, vendor, clusters] = await Promise.all([
     getTeamSummary(team.id),
-    getVendorByUserId(team.id),
+    getVendor(team.id),
     getActiveClusters({ teamId: team.id }),
   ])
 
@@ -87,12 +93,12 @@ export default async function TeamDetailsPage({
     {
       key: "total-proofs",
       label: "proofs",
-      value: teamSummary.total_proofs_single || <Null />,
+      value: teamSummary?.total_proofs_single || <Null />,
     },
     {
       key: "avg-cost",
       label: "avg cost",
-      value: teamSummary.avg_cost_per_proof_single ? (
+      value: teamSummary?.avg_cost_per_proof_single ? (
         formatUsd(teamSummary.avg_cost_per_proof_single)
       ) : (
         <Null />
@@ -102,8 +108,8 @@ export default async function TeamDetailsPage({
       key: "avg-time",
       label: "avg time",
       value:
-        Number(teamSummary.avg_proving_time_single) > 0 ? (
-          prettyMs(Number(teamSummary.avg_proving_time_single))
+        Number(teamSummary?.avg_proving_time_single) > 0 ? (
+          prettyMs(Number(teamSummary?.avg_proving_time_single))
         ) : (
           <Null />
         ),
@@ -114,13 +120,13 @@ export default async function TeamDetailsPage({
     {
       key: "total-proofs",
       label: "proofs",
-      value: teamSummary.total_proofs_multi || <Null />,
+      value: teamSummary?.total_proofs_multi || <Null />,
     },
     {
       key: "avg-cost",
       label: "avg cost",
-      value: teamSummary.avg_cost_per_proof_multi ? (
-        formatUsd(teamSummary.avg_cost_per_proof_multi)
+      value: teamSummary?.avg_cost_per_proof_multi ? (
+        formatUsd(teamSummary?.avg_cost_per_proof_multi)
       ) : (
         <Null />
       ),
@@ -129,8 +135,8 @@ export default async function TeamDetailsPage({
       key: "avg-time",
       label: "avg time",
       value:
-        Number(teamSummary.avg_proving_time_multi) > 0 ? (
-          prettyMs(Number(teamSummary.avg_proving_time_multi))
+        Number(teamSummary?.avg_proving_time_multi) > 0 ? (
+          prettyMs(Number(teamSummary?.avg_proving_time_multi))
         ) : (
           <Null />
         ),

--- a/app/teams/[teamId]/page.tsx
+++ b/app/teams/[teamId]/page.tsx
@@ -57,8 +57,9 @@ export default async function TeamDetailsPage({
     if (!team) {
       // if team is not found, try to get vendor
       // NOTE: edge case for handling only vendor pages
-      // @ts-expect-error expected: vendor does not have `storage_quota_bytes`
-      team = await getVendorByIdOrSlug(teamId)
+      const vendor = await getVendorByIdOrSlug(teamId)
+      // Convert to Team interface: vendor does not have `storage_quota_bytes`
+      if (vendor) team = { ...vendor, storage_quota_bytes: null }
     }
 
     if (!team) {

--- a/lib/api/vendor.ts
+++ b/lib/api/vendor.ts
@@ -1,8 +1,0 @@
-import { db } from "@/db"
-
-export const getVendorByUserId = async (userId: string) => {
-  const vendor = await db.query.vendors.findFirst({
-    where: (vendors, { eq }) => eq(vendors.user_id, userId),
-  })
-  return vendor
-}

--- a/lib/api/vendors.ts
+++ b/lib/api/vendors.ts
@@ -1,0 +1,17 @@
+import { isUUID } from "../utils"
+
+import { db } from "@/db"
+
+export const getVendor = async (userId: string) => {
+  const vendor = await db.query.vendors.findFirst({
+    where: (vendors, { eq }) => eq(vendors.user_id, userId),
+  })
+  return vendor
+}
+
+export const getVendorBySlug = async (slug: string) => {
+  const vendor = await db.query.vendors.findFirst({
+    where: (vendors, { eq }) => eq(vendors.slug, slug),
+  })
+  return vendor
+}

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -1,4 +1,5 @@
 import { getTeam, getTeamBySlug } from "./api/teams"
+import { getVendor, getVendorBySlug } from "./api/vendors"
 import type { TeamSummary } from "./types"
 import { isUUID } from "./utils"
 
@@ -16,4 +17,11 @@ export const getTeamByIdOrSlug = async (idOrSlug: string) => {
     return getTeam(idOrSlug)
   }
   return getTeamBySlug(idOrSlug)
+}
+
+export const getVendorByIdOrSlug = async (idOrSlug: string) => {
+  if (isUUID(idOrSlug)) {
+    return getVendor(idOrSlug)
+  }
+  return getVendorBySlug(idOrSlug)
 }


### PR DESCRIPTION
- first, tries to fetch the team. If it doesn't exist, then it tries to load a vendor
- teamSummary can now be undefined in this scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for fetching vendor information by either ID or slug, providing a fallback mechanism when team data is unavailable.

- **Bug Fixes**
  - Improved error handling to ensure a 404 error is shown if neither team nor vendor data is found.
  - Enhanced robustness by safely handling missing summary data in the team details view.

- **Chores**
  - Removed unused code and reorganized vendor data fetching utilities for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->