### PR TITLE
fix team link to use slug

### DIFF
--- a/components/BlocksTable/TeamName.tsx
+++ b/components/BlocksTable/TeamName.tsx
@@ -5,7 +5,7 @@ import type { Proof } from "@/lib/types"
 const TeamName = ({ proof: { team, team_id } }: { proof: Proof }) => {
   if (!team) return `Team ${team_id.split("-")[0]}`
   return (
-    <Link href={"/teams/" + team.id} className="text-xl text-primary underline">
+    <Link href={"/teams/" + team.slug} className="text-xl text-primary underline">
       {team.name}
     </Link>
   )

--- a/components/ProofRow.tsx
+++ b/components/ProofRow.tsx
@@ -87,7 +87,7 @@ const ProofRow = ({ proof, block }: ProofRowProps) => {
         <div className="flex flex-col gap-2">
           {team?.name && (
             <Link
-              href={"/teams/" + team?.id}
+              href={"/teams/" + team?.slug}
               className="text-2xl hover:text-primary-light hover:underline"
             >
               {team.name}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated team links to use team slugs in URLs instead of team IDs for improved navigation consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->