### PR TITLE
sort zkvms list

### DIFF
--- a/components/SoftwareAccordion.tsx
+++ b/components/SoftwareAccordion.tsx
@@ -107,6 +107,9 @@ const SoftwareAccordion = async () => {
     zkvmIds: zkvms.map((zkvm) => zkvm.id),
   })
 
+  // sort zkvms by usage
+  const sortedZkvms = zkvms.sort((a, b) => b.activeClusters - a.activeClusters)
+
   return (
     <Accordion
       type="multiple"
@@ -146,7 +149,7 @@ const SoftwareAccordion = async () => {
           </MetricLabel>
         </MetricBox>
       </div>
-      {zkvms.map((zkvm) => (
+      {sortedZkvms.map((zkvm) => (
         <SoftwareAccordionItem
           key={zkvm.id}
           value={"item-" + zkvm.id}

--- a/lib/zkvms.ts
+++ b/lib/zkvms.ts
@@ -31,6 +31,7 @@ export const getZkvmsWithUsage = async () => {
     const totalClusters = totalActiveClusters
     return { ...zkvm, totalClusters, activeClusters }
   })
+
   return zkvmsWithUsage
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the display order of zkVM items in the accordion to prioritize those with higher active cluster counts. The most active zkVMs now appear first in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->