### PR TITLE
fix zkvm last update date

### DIFF
--- a/components/SoftwareAccordion.tsx
+++ b/components/SoftwareAccordion.tsx
@@ -92,7 +92,9 @@ const SoftwareAccordionItem = ({
               Last updated
             </span>{" "}
             <span className="text-xs uppercase text-body">
-              {formatShortDate(new Date(zkvm.created_at))}
+              {metrics.updated_at
+                ? formatShortDate(new Date(metrics.updated_at))
+                : "N/A"}
             </span>
           </div>
         </div>

--- a/components/SoftwareAccordion.tsx
+++ b/components/SoftwareAccordion.tsx
@@ -33,7 +33,7 @@ const SoftwareAccordionItem = ({
     totalClusters: number
     activeClusters: number
   }
-  metrics: Partial<ZkvmMetrics>
+  metrics: Partial<ZkvmMetrics> | undefined
 }) => {
   const detailItems = getSoftwareDetailItems(metrics)
 
@@ -87,16 +87,16 @@ const SoftwareAccordionItem = ({
             details for {zkvm.name}
             <ChevronRight className="-mx-2 size-4" />
           </ButtonLink>
-          <div className="col-start-3 text-end">
-            <span className="text-xs italic text-body-secondary">
-              Last updated
-            </span>{" "}
-            <span className="text-xs uppercase text-body">
-              {metrics.updated_at
-                ? formatShortDate(new Date(metrics.updated_at))
-                : "N/A"}
-            </span>
-          </div>
+          {metrics?.updated_at && (
+            <div className="col-start-3 text-end">
+              <span className="text-xs italic text-body-secondary">
+                Last updated
+              </span>{" "}
+              <span className="text-xs uppercase text-body">
+                {formatShortDate(new Date(metrics.updated_at))}
+              </span>
+            </div>
+          )}
         </div>
       </AccordionContent>
     </AccordionItem>
@@ -153,7 +153,7 @@ const SoftwareAccordion = async () => {
           key={zkvm.id}
           value={"item-" + zkvm.id}
           zkvm={zkvm}
-          metrics={metricsByZkvmId.get(zkvm.id) || {}}
+          metrics={metricsByZkvmId.get(zkvm.id)}
         />
       ))}
     </Accordion>

--- a/lib/metrics.tsx
+++ b/lib/metrics.tsx
@@ -148,8 +148,8 @@ export const getZkvmsMetricsByZkvmId = async ({
   const metricsByZkvmId = new Map<number, Partial<ZkvmMetrics>>()
 
   for (const zkvm of zkvmsWithMetrics) {
-    const securityMetricsUpdatedAt = zkvm.security_metrics.updated_at
-    const performanceMetricsUpdatedAt = zkvm.performance_metrics.updated_at
+    const securityMetricsUpdatedAt = zkvm.security_metrics?.updated_at
+    const performanceMetricsUpdatedAt = zkvm.performance_metrics?.updated_at
 
     const lastUpdated =
       securityMetricsUpdatedAt > performanceMetricsUpdatedAt
@@ -177,7 +177,7 @@ export const getZkvmMetrics = async (zkvmId: number) => {
 }
 
 export const getSoftwareDetailItems = (
-  metrics: Partial<ZkvmMetrics>
+  metrics: Partial<ZkvmMetrics> = {}
 ): SoftwareDetailItem[] => {
   const severityLevels = getZkvmMetricSeverityLevels(metrics)
 

--- a/lib/metrics.tsx
+++ b/lib/metrics.tsx
@@ -148,9 +148,18 @@ export const getZkvmsMetricsByZkvmId = async ({
   const metricsByZkvmId = new Map<number, Partial<ZkvmMetrics>>()
 
   for (const zkvm of zkvmsWithMetrics) {
+    const securityMetricsUpdatedAt = zkvm.security_metrics.updated_at
+    const performanceMetricsUpdatedAt = zkvm.performance_metrics.updated_at
+
+    const lastUpdated =
+      securityMetricsUpdatedAt > performanceMetricsUpdatedAt
+        ? securityMetricsUpdatedAt
+        : performanceMetricsUpdatedAt
+
     metricsByZkvmId.set(zkvm.id, {
       ...zkvm.security_metrics,
       ...zkvm.performance_metrics,
+      updated_at: lastUpdated,
     })
   }
 


### PR DESCRIPTION
Display last updated date from metrics in the zkvm accordions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Last updated" date in the software accordion now dynamically displays the most recent update time from available metrics, or "N/A" if not available, instead of always showing the creation date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->