### PR TITLE
feat: grants banner, closes #413

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react"
 import type { Metadata } from "next"
 
+import GrantsBanner from "@/components/GrantsBanner"
 import ProofsStats from "@/components/ProofsStats"
 import BlocksSection from "@/components/sections/BlocksSection"
 import ClustersSection from "@/components/sections/ClustersSection"
@@ -21,6 +22,12 @@ export default async function Index() {
       <h1 className="text-shadow mb-24 mt-16 px-6 text-center font-mono text-3xl font-semibold md:mt-24 md:px-8">
         Building a fully SNARKed <span className="text-primary">Ethereum</span>
       </h1>
+
+      <div className="mx-auto mb-16 flex max-w-screen-xl flex-col items-center px-6 md:px-8 [&>section]:w-full">
+        <section id="banner">
+          <GrantsBanner />
+        </section>
+      </div>
 
       <div className="mx-auto flex max-w-screen-xl flex-col items-center gap-20 px-6 md:px-8 [&>section]:w-full">
         <ProofsStats recentSummary={recentSummary} />

--- a/components/BlocksTable/TeamName.tsx
+++ b/components/BlocksTable/TeamName.tsx
@@ -5,7 +5,10 @@ import type { Proof } from "@/lib/types"
 const TeamName = ({ proof: { team, team_id } }: { proof: Proof }) => {
   if (!team) return `Team ${team_id.split("-")[0]}`
   return (
-    <Link href={"/teams/" + team.slug} className="text-xl text-primary underline">
+    <Link
+      href={"/teams/" + team.slug}
+      className="text-xl text-primary underline"
+    >
       {team.name}
     </Link>
   )

--- a/components/GrantsBanner.tsx
+++ b/components/GrantsBanner.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useState } from "react"
+
+import Close from "@/components/svgs/close.svg"
+
+import { Alert, AlertTitle } from "./ui/alert"
+import Link from "./ui/link"
+
+const learnMoreLink = "https://x.com/eth_proofs/status/1930244636582334473"
+
+const GrantsBanner = () => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  function onDismiss() {
+    setIsOpen(false)
+  }
+
+  return (
+    isOpen && (
+      <Alert className="flex w-full items-center justify-between rounded-2xl border-[1.48px] border-primary-border bg-background-highlight px-6 py-4 text-body">
+        <AlertTitle className="text-base font-normal">
+          Ethproofs is accelerating real-time proving with $300k in grants to
+          incentivize breakthrough performance. Learn more{" "}
+          <Link href={learnMoreLink}>here</Link>
+        </AlertTitle>
+        <button onClick={onDismiss}>
+          <Close />
+        </button>
+      </Alert>
+    )
+  )
+}
+
+export default GrantsBanner

--- a/components/svgs/close.svg
+++ b/components/svgs/close.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#031C1E"/>
+<path d="M7.39697 7.39691L16.6031 16.6031" stroke="#25E270" stroke-width="1.5"/>
+<path d="M16.603 7.39691L7.39685 16.6031" stroke="#25E270" stroke-width="1.5"/>
+</svg>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertDescription, AlertTitle }


### PR DESCRIPTION
This PR adds a banner component and uses it to create a `GrantsBanner` to promote Ethproofs grants. The `Learn more` link goes to this post: https://x.com/eth_proofs/status/1930244636582334473

<img width="1512" alt="Screenshot 2025-06-04 at 8 28 51 PM" src="https://github.com/user-attachments/assets/a624e589-0f9b-4aa8-8088-05fbce0226cb" />

<img width="1510" alt="Screenshot 2025-06-04 at 8 28 31 PM" src="https://github.com/user-attachments/assets/90d4b00c-42db-4b5e-aa89-7e65760be423" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dismissible Grants Banner highlighting Ethproofs grants, now displayed prominently on the main page.
  - Added new alert UI components for consistent and styled messaging across the application.

- **Style**
  - Improved formatting of the TeamName component for better code readability (no user-facing impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue
- Closes #413 