### PR TITLE
fix: total cpu ram, closes #426

### DIFF
--- a/components/ClusterMachineSummary.tsx
+++ b/components/ClusterMachineSummary.tsx
@@ -76,7 +76,12 @@ const ClusterMachineSummary = ({
           <span className="block font-mono text-xl text-body">
             {sumArray(
               machines.map(
-                (m) => sumArray(m.machine.memory_size_gb) * m.machine_count
+                (m) =>
+                  (m.machine.memory_size_gb?.reduce(
+                    (total, size, i) =>
+                      total + size * (m.machine.memory_count?.[i] || 0),
+                    0
+                  ) ?? 0) * m.machine_count
               )
             )}{" "}
             GB

--- a/components/ui/MachineDetails.tsx
+++ b/components/ui/MachineDetails.tsx
@@ -22,7 +22,16 @@ const MachineDetails = ({
         </div>
         <div className="flex flex-1 flex-col items-center p-2">
           <div className="text-nowrap text-body-secondary">CPU RAM</div>
-          <div className="">{sumArray(machine.memory_size_gb)} GB</div>
+          <div className="">
+            <div className="">
+              {machine.memory_size_gb?.reduce(
+                (total, size, i) =>
+                  total + size * (machine.memory_count?.[i] || 0),
+                0
+              ) ?? 0}{" "}
+              GB
+            </div>
+          </div>
         </div>
       </div>
       <div className="flex flex-col gap-y-3">


### PR DESCRIPTION
Fixes a reported UI bug where the `memory_count` wasn't being used to calculate the total `CPU RAM` shown.

Bug...
<img width="333" alt="Screenshot 2025-07-08 at 12 26 50 PM" src="https://github.com/user-attachments/assets/6a834600-9029-4528-bcd6-ab6a97c86c02" />

Fixed...
<img width="309" alt="Screenshot 2025-07-08 at 12 26 41 PM" src="https://github.com/user-attachments/assets/917004fe-07a4-44aa-b997-d0ede8bc501d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calculation of total CPU RAM in cluster and machine summaries to accurately account for both memory size and quantity, ensuring displayed RAM values are precise and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->