### PR TITLE
fix: link cluster to zkvm

### DIFF
--- a/app/clusters/[clusterId]/page.tsx
+++ b/app/clusters/[clusterId]/page.tsx
@@ -162,7 +162,12 @@ export default async function ClusterDetailsPage({
       <section className="!mt-16 flex w-full flex-wrap justify-evenly gap-x-8 border-b">
         <div className="flex flex-col items-center gap-1 p-4">
           <div className="font-sans text-sm text-body-secondary">zkVM</div>
-          <div className="font-mono text-lg text-primary">{zkvm.name}</div>
+          <Link
+            href={`/zkvms/${zkvm.slug}`}
+            className="font-mono text-lg text-primary hover:underline"
+          >
+            {zkvm.name}
+          </Link>
         </div>
         <div className="flex flex-col items-center gap-1 p-4">
           <MetricBox className="py-0">

--- a/lib/zkvms.ts
+++ b/lib/zkvms.ts
@@ -3,16 +3,10 @@ import { Slices, SoftwareDetailItem } from "./types"
 import { getActiveClusterCountByZkvmId } from "@/lib/api/clusters"
 import { getZkvm, getZkvms } from "@/lib/api/zkvms"
 
-export const getZkvmsStats = async () => {
-  const zkvms = await getZkvms()
-  const zkvmsCount = zkvms.length
-
-  const isas = new Set(zkvms.map((zkvm) => zkvm.isa))
-
-  return {
-    count: zkvmsCount,
-    isas: Array.from(isas),
-  }
+export const getActiveZkvms = async () => {
+  const zkvms = await getZkvmsWithUsage()
+  const activeZkvms = zkvms.filter((zkvm) => zkvm.activeClusters > 0)
+  return activeZkvms
 }
 
 export const getZkvmsWithUsage = async () => {
@@ -62,6 +56,18 @@ export const getZkvmWithUsage = async ({
     ...zkvm,
     totalClusters,
     activeClusters,
+  }
+}
+
+export const getZkvmsStats = async () => {
+  const zkvms = await getActiveZkvms()
+  const zkvmsCount = zkvms.length
+
+  const isas = new Set(zkvms.map((zkvm) => zkvm.isa))
+
+  return {
+    count: zkvmsCount,
+    isas: Array.from(isas),
   }
 }
 


### PR DESCRIPTION
This PR adds a link b/w the cluster and the zkVM it is using. Requested change by @alexanderlhicks!

In addition, I've filtered the zkVMs total on the dashboard to show only active zkVMs so that the 'coming soon' zkVMs are not listed in the total.

https://github.com/user-attachments/assets/61e00bdc-5050-4fa3-bae4-348c433dcd82

