### PR TITLE
Fix dead links and broken redirects

### DIFF
--- a/components/LearnMore.tsx
+++ b/components/LearnMore.tsx
@@ -13,7 +13,7 @@ export default function LearnMore() {
           <h3 className="max-w-72 text-3xl md:max-w-96">
             Why do we need to verify each block?
           </h3>
-          <Link href="/TODO-ADD-LINK" className="font-body">
+          <Link href="/learn" className="font-body">
             Learn more
           </Link>
         </div>
@@ -23,7 +23,7 @@ export default function LearnMore() {
           <h3 className="max-w-72 text-3xl md:max-w-96">
             How do the proofs work?
           </h3>
-          <Link href="/TODO-ADD-LINK" className="font-body">
+          <Link href="/learn" className="font-body">
             Learn more
           </Link>
         </div>


### PR DESCRIPTION

- **LearnMore component**: Replaced placeholder links `/TODO-ADD-LINK` with actual `/learn` routes

## Changes made
- `components/LearnMore.tsx` - Fixed 2 placeholder links



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated "Learn more" links to direct users to the correct "/learn" page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->