### PR TITLE
Daily proof monitoring cron job

### DIFF
--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -43,7 +43,7 @@ BEGIN
     -- Clear temp table
     DELETE FROM missing_proofs_temp;
 
-    -- Find all missing proofs
+    -- Find all missing proofs from the previous day
     INSERT INTO missing_proofs_temp (team_name, cluster_nickname, block_number)
     SELECT c.team_name, c.nickname, b.block_number
     FROM blocks b
@@ -53,7 +53,8 @@ BEGIN
         JOIN teams t ON t.id = c.team_id
         WHERE c.is_active = true
     ) c
-    WHERE b.timestamp >= NOW() - INTERVAL '24 hours'
+    WHERE b.timestamp >= CURRENT_DATE - INTERVAL '1 day'
+      AND b.timestamp < CURRENT_DATE
       AND b.block_number % 100 = 0
       AND NOT EXISTS (
           SELECT 1

--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -186,7 +186,7 @@ BEGIN
         END IF;
 
         message_text := message_text || E'▪️ *' || escape_markdown_v2(cluster.team_name) || '* \- ' || escape_markdown_v2(cluster.cluster_nickname) || ' \(…' || escape_markdown_v2(cluster.cluster_id_suffix) || E'\\)\n';
-        message_text := message_text || E'   Missing blocks: `' || display_blocks || E'`\n\n';
+        message_text := message_text || E'   Missing proofs for blocks: `' || display_blocks || E'`\n\n';
     END LOOP;
     
     -- Send to internal Telegram chat
@@ -237,7 +237,7 @@ BEGIN
 
         -- Add header with title and date context
         message_text := E'🚨 *Missing Proof Alert*\n\n' ||
-                        E'_Found *' || total_missing || '* missing proofs from yesterday \(' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E'\\)_\n';
+                        E'Missing proofs for *' || total_missing || '* blocks from yesterday \(' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E'\\) have been detected\\. \n';
         cluster_count := 0;
         
         -- Process each cluster for this team
@@ -275,6 +275,8 @@ BEGIN
                 message_text := message_text || E'\n';
             END IF;
         END LOOP;
+
+        message_text := message_text || E'\nPlease confirm your prover is online and submitting proofs for every 100 blocks\\.';
         
         -- Send to team's Telegram chat
         telegram_response := send_telegram_message(team_record.chat_id, message_text, telegram_bot_token);

--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -112,7 +112,7 @@ BEGIN
         SELECT c.id, c.nickname, c.team_id, t.name as team_name
         FROM clusters c
         JOIN teams t ON t.id = c.team_id
-        -- WHERE c.is_active = true
+        WHERE c.is_active = true
     ) c
     WHERE b.timestamp >= CURRENT_DATE - INTERVAL '1 day'
       AND b.timestamp < CURRENT_DATE
@@ -133,7 +133,6 @@ BEGIN
 END;
 $$;
 
--- Modified version that doesn't manage temp table lifecycle
 CREATE OR REPLACE FUNCTION send_internal_summary_from_temp()
 RETURNS void
 LANGUAGE plpgsql
@@ -232,7 +231,6 @@ BEGIN
 
         -- Add header with title and date context
         message_text := E'🚨 *Missing Proof Alert*\n\n' ||
-                        -- E'*Date:* ' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E'\n\n' ||
                         E'_Found *' || total_missing || '* missing proofs from yesterday \(' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E'\\)_\n';
         cluster_count := 0;
         
@@ -307,7 +305,7 @@ BEGIN
     
     RAISE LOG 'Found % missing proofs, sending alerts...', missing_count;
     
-    -- PERFORM send_internal_summary_from_temp();
+    PERFORM send_internal_summary_from_temp();
     
     -- 1 second delay before team alerts to avoid rate limits
     PERFORM pg_sleep(1);

--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -2,40 +2,100 @@
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 CREATE EXTENSION IF NOT EXISTS pg_net;
 
-CREATE OR REPLACE FUNCTION check_missing_proofs()
-RETURNS void
+-- Add chat_id column to teams table for Telegram bot integration
+ALTER TABLE "teams" ADD COLUMN IF NOT EXISTS "chat_id" text;
+
+-- Helper function to escape MarkdownV2 reserved characters
+CREATE OR REPLACE FUNCTION escape_markdown_v2(input_text TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+BEGIN
+    IF input_text IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- MarkdownV2 reserved characters: _ *  ~ ` > # + - = | { } . !
+    input_text := replace(input_text, '_', '\_');
+    input_text := replace(input_text, '[', '\[');
+    input_text := replace(input_text, ']', '\]');
+    input_text := replace(input_text, '(', '\(');
+    input_text := replace(input_text, ')', '\)');
+    input_text := replace(input_text, '~', '\~');
+    input_text := replace(input_text, '`', '\`');
+    input_text := replace(input_text, '>', '\>');
+    input_text := replace(input_text, '#', '\#');
+    input_text := replace(input_text, '+', '\+');
+    input_text := replace(input_text, '-', '\-');
+    input_text := replace(input_text, '=', '\=');
+    input_text := replace(input_text, '|', '\|');
+    input_text := replace(input_text, '{', '\{');
+    input_text := replace(input_text, '}', '\}');
+    input_text := replace(input_text, '.', '\.');
+    input_text := replace(input_text, '!', '\!');
+
+    RETURN input_text;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_telegram_bot_token()
+RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
-    cluster RECORD;
-    missing_count INTEGER := 0;
-    message_text TEXT := '';
-    telegram_response RECORD;
-    telegram_url TEXT;
-    telegram_bot_token TEXT;
-    telegram_chat_id TEXT;
-    team_missing_blocks TEXT := '';
+    bot_token TEXT;
 BEGIN
-    -- Get Telegram configuration from Vault
-    SELECT decrypted_secret INTO telegram_bot_token 
+    SELECT decrypted_secret INTO bot_token 
     FROM vault.decrypted_secrets 
     WHERE name = 'telegram_bot_token';
     
-    SELECT decrypted_secret INTO telegram_chat_id 
-    FROM vault.decrypted_secrets 
-    WHERE name = 'telegram_chat_id';
+    RETURN bot_token;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION send_telegram_message(chat_id TEXT, message_text TEXT, bot_token TEXT)
+RETURNS RECORD
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    telegram_response RECORD;
+    telegram_url TEXT;
+BEGIN
+    telegram_url := 'https://api.telegram.org/bot' || bot_token || '/sendMessage';
+
+    RAISE LOG 'Sending Telegram message to %: %', chat_id, message_text;
     
-    IF telegram_bot_token IS NULL OR telegram_chat_id IS NULL THEN
-        RAISE LOG 'Telegram configuration not found in Vault (telegram_bot_token or telegram_chat_id missing). Skipping alert.';
-        RETURN;
-    END IF;
+    SELECT INTO telegram_response
+        net.http_post(
+            url := telegram_url,
+            headers := '{"Content-Type": "application/json"}'::jsonb,
+            body := jsonb_build_object(
+                'chat_id', chat_id,
+                'text', message_text,
+                'parse_mode', 'MarkdownV2'
+            )
+        );
+    
+    RETURN telegram_response;
+END;
+$$;
 
-    RAISE LOG 'Starting proof monitoring check...';
-
+CREATE OR REPLACE FUNCTION populate_missing_proofs_temp()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    missing_count INTEGER;
+BEGIN
     -- Create temporary table to collect missing proofs
     CREATE TEMP TABLE IF NOT EXISTS missing_proofs_temp (
+        team_id UUID,
         team_name TEXT,
+        cluster_id UUID,
         cluster_nickname TEXT,
         cluster_id_suffix TEXT,
         block_number BIGINT
@@ -45,14 +105,14 @@ BEGIN
     DELETE FROM missing_proofs_temp;
 
     -- Find all missing proofs from the previous day
-    INSERT INTO missing_proofs_temp (team_name, cluster_nickname, cluster_id_suffix, block_number)
-    SELECT c.team_name, c.nickname, RIGHT(c.id::text, 6), b.block_number
+    INSERT INTO missing_proofs_temp (team_id, team_name, cluster_id, cluster_nickname, cluster_id_suffix, block_number)
+    SELECT c.team_id, c.team_name, c.id, c.nickname, RIGHT(c.id::text, 6), b.block_number
     FROM blocks b
     CROSS JOIN LATERAL (
         SELECT c.id, c.nickname, c.team_id, t.name as team_name
         FROM clusters c
         JOIN teams t ON t.id = c.team_id
-        WHERE c.is_active = true
+        -- WHERE c.is_active = true
     ) c
     WHERE b.timestamp >= CURRENT_DATE - INTERVAL '1 day'
       AND b.timestamp < CURRENT_DATE
@@ -68,80 +128,202 @@ BEGIN
     
     -- Get the count of missing proofs
     SELECT COUNT(*) INTO missing_count FROM missing_proofs_temp;
-
-    RAISE LOG 'Found % missing proofs', missing_count;
-
-    -- Only send alert if there are missing proofs
-    IF missing_count > 0 THEN
-        message_text := E'🚨 *Missing Proof Alert*\n\nFound ' || missing_count || E' missing proofs in the last 24 hours:\n\n';
-        
-        -- Group missing proofs by team and cluster for better readability
-        FOR cluster IN
-            SELECT DISTINCT team_name, cluster_nickname, cluster_id_suffix
-            FROM missing_proofs_temp
-            ORDER BY team_name, cluster_nickname
-        LOOP
-            -- Get missing blocks for this team/cluster combination
-            SELECT string_agg(block_number::text, ', ' ORDER BY block_number)
-            INTO team_missing_blocks
-            FROM missing_proofs_temp
-            WHERE team_name = cluster.team_name 
-              AND cluster_nickname = cluster.cluster_nickname
-              AND cluster_id_suffix = cluster.cluster_id_suffix;
-            
-            message_text := message_text || '*' || cluster.team_name || '* - ' || cluster.cluster_nickname || ' (...' || cluster.cluster_id_suffix || ')' || E'\n';
-            message_text := message_text || 'Missing blocks: ' || team_missing_blocks || E'\n\n';
-        END LOOP;
-        
-        message_text := message_text || E'\nTime: ' || NOW()::text;
-        
-        -- Escape all reserved characters for MarkdownV2
-        -- MarkdownV2 reserved characters: _ * [ ] ( ) ~ ` > # + - = | { } . !
-        message_text := replace(message_text, '_', '\_');
-        message_text := replace(message_text, '[', '\[');
-        message_text := replace(message_text, ']', '\]');
-        message_text := replace(message_text, '(', '\(');
-        message_text := replace(message_text, ')', '\)');
-        message_text := replace(message_text, '~', '\~');
-        message_text := replace(message_text, '`', '\`');
-        message_text := replace(message_text, '>', '\>');
-        message_text := replace(message_text, '#', '\#');
-        message_text := replace(message_text, '+', '\+');
-        message_text := replace(message_text, '-', '\-');
-        message_text := replace(message_text, '=', '\=');
-        message_text := replace(message_text, '|', '\|');
-        message_text := replace(message_text, '{', '\{');
-        message_text := replace(message_text, '}', '\}');
-        message_text := replace(message_text, '.', '\.');
-        message_text := replace(message_text, '!', '\!');
-        
-        -- Send to Telegram using pg_net
-        telegram_url := 'https://api.telegram.org/bot' || telegram_bot_token || '/sendMessage';
-        
-        SELECT INTO telegram_response
-            net.http_post(
-                url := telegram_url,
-                headers := '{"Content-Type": "application/json"}'::jsonb,
-                body := jsonb_build_object(
-                    'chat_id', telegram_chat_id,
-                    'text', message_text,
-                    'parse_mode', 'MarkdownV2'
-                )
-            );
-        
-        RAISE LOG 'Telegram alert sent. Response: %', telegram_response;
-    ELSE
-        RAISE LOG 'All active clusters are up to date with proof submissions';
-    END IF;
-
-    -- Clean up
-    DROP TABLE IF EXISTS missing_proofs_temp;
+    
+    RETURN missing_count;
 END;
 $$;
 
--- Run daily at 1 PM UTC (8 AM NY / 2 PM Europe)
+-- Modified version that doesn't manage temp table lifecycle
+CREATE OR REPLACE FUNCTION send_internal_summary_from_temp()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    cluster RECORD;
+    missing_count INTEGER;
+    message_text TEXT := '';
+    telegram_response RECORD;
+    telegram_bot_token TEXT;
+    telegram_chat_id TEXT;
+    team_missing_blocks TEXT;
+BEGIN
+    -- Get Telegram configuration
+    telegram_bot_token := get_telegram_bot_token();
+    
+    SELECT decrypted_secret INTO telegram_chat_id 
+    FROM vault.decrypted_secrets 
+    WHERE name = 'telegram_chat_id';
+    
+    IF telegram_bot_token IS NULL OR telegram_chat_id IS NULL THEN
+        RAISE LOG 'Telegram configuration not found in Vault. Skipping internal alert.';
+        RETURN;
+    END IF;
+
+    -- Get count from existing temp table
+    SELECT COUNT(*) INTO missing_count FROM missing_proofs_temp;
+    
+    RAISE LOG 'Sending internal summary for % missing proofs', missing_count;
+
+    message_text := E'🚨 *Missing Proof Alert*\n\nFound ' || missing_count || E' missing proofs on ' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E':\n\n';
+    
+    FOR cluster IN
+        SELECT DISTINCT team_name, cluster_nickname, cluster_id_suffix
+        FROM missing_proofs_temp
+        ORDER BY team_name, cluster_nickname
+    LOOP
+        -- Get missing blocks for this team/cluster combination
+        SELECT string_agg(block_number::text, ', ' ORDER BY block_number)
+        INTO team_missing_blocks
+        FROM missing_proofs_temp
+        WHERE team_name = cluster.team_name 
+          AND cluster_nickname = cluster.cluster_nickname
+          AND cluster_id_suffix = cluster.cluster_id_suffix;
+
+        message_text := message_text || E'▪️ *' || escape_markdown_v2(cluster.team_name) || '* \- ' || escape_markdown_v2(cluster.cluster_nickname) || ' \(…' || escape_markdown_v2(cluster.cluster_id_suffix) || E'\\)\n';
+        message_text := message_text || E'   Missing blocks: `' || team_missing_blocks || E'`\n\n';
+    END LOOP;
+    
+    -- Send to internal Telegram chat
+    telegram_response := send_telegram_message(telegram_chat_id, message_text, telegram_bot_token);
+    
+    RAISE LOG 'Internal summary sent. Response: %', telegram_response;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION send_team_alerts_from_temp()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    team_record RECORD;
+    cluster_record RECORD;
+    missing_blocks TEXT[];
+    display_blocks TEXT;
+    message_text TEXT;
+    telegram_response RECORD;
+    telegram_bot_token TEXT;
+    cluster_count INTEGER;
+    total_missing INTEGER;
+    cluster_link TEXT;
+BEGIN
+    -- Get Telegram bot token
+    telegram_bot_token := get_telegram_bot_token();
+    
+    IF telegram_bot_token IS NULL THEN
+        RAISE LOG 'Telegram bot token not found in Vault. Skipping team alerts.';
+        RETURN;
+    END IF;
+
+    RAISE LOG 'Starting team-specific alerts from existing data...';
+
+    -- Send alerts to each team that has chat_id configured
+    FOR team_record IN
+        SELECT DISTINCT tmp.team_id, tmp.team_name, t.chat_id
+        FROM missing_proofs_temp tmp
+        JOIN teams t ON t.id = tmp.team_id
+        WHERE t.chat_id IS NOT NULL
+    LOOP
+        -- Count total missing blocks for this team
+        SELECT COUNT(*) INTO total_missing
+        FROM missing_proofs_temp
+        WHERE team_id = team_record.team_id;
+
+        -- Add header with title and date context
+        message_text := E'🚨 *Missing Proof Alert*\n\n' ||
+                        -- E'*Date:* ' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E'\n\n' ||
+                        E'_Found *' || total_missing || '* missing proofs from yesterday \(' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E'\\)_\n';
+        cluster_count := 0;
+        
+        -- Process each cluster for this team
+        FOR cluster_record IN
+            SELECT DISTINCT cluster_id, cluster_nickname, cluster_id_suffix
+            FROM missing_proofs_temp
+            WHERE team_id = team_record.team_id
+            ORDER BY cluster_nickname
+        LOOP
+            cluster_count := cluster_count + 1;
+            
+            -- Get missing blocks for this cluster (first 3 + count)
+            SELECT array_agg(block_number ORDER BY block_number) INTO missing_blocks
+            FROM missing_proofs_temp
+            WHERE team_id = team_record.team_id 
+              AND cluster_id = cluster_record.cluster_id;
+            
+            IF array_length(missing_blocks, 1) > 3 THEN
+                display_blocks := missing_blocks[1] || ', ' || missing_blocks[2] || ', ' || missing_blocks[3] || ' +' || (array_length(missing_blocks, 1) - 3) || ' more';
+            ELSE
+                display_blocks := array_to_string(missing_blocks, ', ');
+            END IF;
+            
+            IF cluster_count = 1 THEN
+                message_text := message_text || E'\n';
+            END IF;
+
+            cluster_link := E'https://ethproofs.com/cluster/' || cluster_record.cluster_id;
+            cluster_link := escape_markdown_v2(cluster_link);
+
+            message_text := message_text || E' • [*' || cluster_record.cluster_nickname || '* \(…' || cluster_record.cluster_id_suffix || '\)](' || cluster_link || E')\n' ||
+                           E'   Missing blocks: `' || display_blocks || E'`\n';
+            
+            IF cluster_count < (SELECT COUNT(DISTINCT cluster_id) FROM missing_proofs_temp WHERE team_id = team_record.team_id) THEN
+                message_text := message_text || E'\n';
+            END IF;
+        END LOOP;
+        
+        -- Send to team's Telegram chat
+        telegram_response := send_telegram_message(team_record.chat_id, message_text, telegram_bot_token);
+        
+        RAISE LOG 'Team alert sent to % (chat_id: %). Response: %', team_record.team_name, team_record.chat_id, telegram_response;
+        
+        -- 1 second delay between team alerts to avoid rate limits
+        PERFORM pg_sleep(1);
+    END LOOP;
+
+    RAISE LOG 'Team alerts from temp completed';
+END;
+$$;
+
+-- Send both internal summary and team alerts
+CREATE OR REPLACE FUNCTION send_proof_alerts()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    missing_count INTEGER;
+BEGIN
+    RAISE LOG 'Starting proof monitoring alerts...';
+    
+    -- Get missing proofs data once
+    missing_count := populate_missing_proofs_temp();
+    
+    IF missing_count = 0 THEN
+        RAISE LOG 'All active clusters are up to date with proof submissions';
+        DROP TABLE IF EXISTS missing_proofs_temp;
+        RETURN;
+    END IF;
+    
+    RAISE LOG 'Found % missing proofs, sending alerts...', missing_count;
+    
+    -- PERFORM send_internal_summary_from_temp();
+    
+    -- 1 second delay before team alerts to avoid rate limits
+    PERFORM pg_sleep(1);
+    
+    PERFORM send_team_alerts_from_temp();
+    
+    -- Clean up
+    DROP TABLE IF EXISTS missing_proofs_temp;
+    
+    RAISE LOG 'All proof alerts completed';
+END;
+$$;
+
+-- Run daily at 2 PM UTC (9 AM NY / 3 PM Europe) - Both internal summary and team alerts
 SELECT cron.schedule(
-    'proof-monitoring-alert',
-    '0 13 * * *',
-    'SELECT check_missing_proofs();'
+    'proof-monitoring-alerts',
+    '0 14 * * *',
+    'SELECT send_proof_alerts();'
 );

--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -1,0 +1,160 @@
+-- Required extensions
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+CREATE OR REPLACE FUNCTION check_missing_proofs()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    proof_block RECORD;
+    cluster RECORD;
+    existing_proof_count INTEGER;
+    missing_count INTEGER := 0;
+    message_text TEXT := '';
+    telegram_response RECORD;
+    telegram_url TEXT;
+    telegram_bot_token TEXT;
+    telegram_chat_id TEXT;
+    missing_by_team TEXT := '';
+    current_team TEXT := '';
+    current_cluster TEXT := '';
+    team_missing_blocks TEXT := '';
+BEGIN
+    -- Get Telegram configuration from Vault
+    SELECT decrypted_secret INTO telegram_bot_token 
+    FROM vault.decrypted_secrets 
+    WHERE name = 'telegram_bot_token';
+    
+    SELECT decrypted_secret INTO telegram_chat_id 
+    FROM vault.decrypted_secrets 
+    WHERE name = 'telegram_chat_id';
+    
+    IF telegram_bot_token IS NULL OR telegram_chat_id IS NULL THEN
+        RAISE LOG 'Telegram configuration not found in Vault (telegram_bot_token or telegram_chat_id missing). Skipping alert.';
+        RETURN;
+    END IF;
+
+    RAISE LOG 'Starting proof monitoring check...';
+
+    -- Create temporary table to collect missing proofs
+    CREATE TEMP TABLE IF NOT EXISTS missing_proofs_temp (
+        team_name TEXT,
+        cluster_nickname TEXT,
+        block_number BIGINT
+    );
+
+    -- Clear temp table
+    DELETE FROM missing_proofs_temp;
+
+    -- Get blocks from last 24 hours that end in 00 (proof submission blocks)
+    FOR proof_block IN 
+        SELECT block_number, timestamp
+        FROM blocks 
+        WHERE timestamp >= (NOW() - INTERVAL '24 hours')
+          AND block_number % 100 = 0
+        ORDER BY block_number
+    LOOP
+        RAISE LOG 'Checking block %', proof_block.block_number;
+        
+        -- For each proof block, check each active cluster
+        FOR cluster IN
+            SELECT c.id, c.nickname, c.team_id, t.name as team_name
+            FROM clusters c
+            JOIN teams t ON c.team_id = t.id
+            WHERE c.is_active = true
+        LOOP
+            -- Check if this cluster has submitted a proof for this block
+            SELECT COUNT(*)
+            INTO existing_proof_count
+            FROM proofs p
+            JOIN cluster_versions cv ON p.cluster_version_id = cv.id
+            WHERE p.block_number = proof_block.block_number
+              AND cv.cluster_id = cluster.id
+              AND p.proof_status IN ('proved');
+            
+            -- If no proof found, add to missing list
+            IF existing_proof_count = 0 THEN
+                INSERT INTO missing_proofs_temp (team_name, cluster_nickname, block_number)
+                VALUES (cluster.team_name, cluster.nickname, proof_block.block_number);
+                missing_count := missing_count + 1;
+            END IF;
+        END LOOP;
+    END LOOP;
+
+    RAISE LOG 'Found % missing proofs', missing_count;
+
+    -- Only send alert if there are missing proofs
+    IF missing_count > 0 THEN
+        message_text := E'🚨 *Missing Proof Alert*\n\nFound ' || missing_count || E' missing proofs in the last 24 hours:\n\n';
+        
+        -- Group missing proofs by team and cluster for better readability
+        FOR cluster IN
+            SELECT DISTINCT team_name, cluster_nickname
+            FROM missing_proofs_temp
+            ORDER BY team_name, cluster_nickname
+        LOOP
+            -- Get missing blocks for this team/cluster combination
+            SELECT string_agg(block_number::text, ', ' ORDER BY block_number)
+            INTO team_missing_blocks
+            FROM missing_proofs_temp
+            WHERE team_name = cluster.team_name 
+              AND cluster_nickname = cluster.cluster_nickname;
+            
+            message_text := message_text || '*' || cluster.team_name || '* - ' || cluster.cluster_nickname || E'\n';
+            message_text := message_text || 'Missing blocks: ' || team_missing_blocks || E'\n\n';
+        END LOOP;
+        
+        message_text := message_text || E'\nTime: ' || NOW()::text;
+        
+        -- Escape all reserved characters for MarkdownV2
+        -- MarkdownV2 reserved characters: _ * [ ] ( ) ~ ` > # + - = | { } . !
+        message_text := replace(message_text, '_', '\_');
+        message_text := replace(message_text, '[', '\[');
+        message_text := replace(message_text, ']', '\]');
+        message_text := replace(message_text, '(', '\(');
+        message_text := replace(message_text, ')', '\)');
+        message_text := replace(message_text, '~', '\~');
+        message_text := replace(message_text, '`', '\`');
+        message_text := replace(message_text, '>', '\>');
+        message_text := replace(message_text, '#', '\#');
+        message_text := replace(message_text, '+', '\+');
+        message_text := replace(message_text, '-', '\-');
+        message_text := replace(message_text, '=', '\=');
+        message_text := replace(message_text, '|', '\|');
+        message_text := replace(message_text, '{', '\{');
+        message_text := replace(message_text, '}', '\}');
+        message_text := replace(message_text, '.', '\.');
+        message_text := replace(message_text, '!', '\!');
+        
+        -- Send to Telegram using pg_net
+        telegram_url := 'https://api.telegram.org/bot' || telegram_bot_token || '/sendMessage';
+        
+        SELECT INTO telegram_response
+            net.http_post(
+                url := telegram_url,
+                headers := '{"Content-Type": "application/json"}'::jsonb,
+                body := jsonb_build_object(
+                    'chat_id', telegram_chat_id,
+                    'text', message_text,
+                    'parse_mode', 'MarkdownV2'
+                )
+            );
+        
+        RAISE LOG 'Telegram alert sent. Response: %', telegram_response;
+    ELSE
+        RAISE LOG 'All active clusters are up to date with proof submissions';
+    END IF;
+
+    -- Clean up
+    DROP TABLE IF EXISTS missing_proofs_temp;
+END;
+$$;
+
+-- Run daily at 1 PM UTC (8 AM NY / 2 PM Europe)
+SELECT cron.schedule(
+    'proof-monitoring-alert',
+    '0 13 * * *',
+    'SELECT check_missing_proofs();'
+);

--- a/supabase/migrations/meta/0024_snapshot.json
+++ b/supabase/migrations/meta/0024_snapshot.json
@@ -1,0 +1,2329 @@
+{
+  "id": "06e718c5-53f2-4cc4-a0d5-73e7ec3977bd",
+  "prevId": "9c36b8ee-63a8-4f5c-aea0-339001b8e009",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_auth_tokens": {
+      "name": "api_auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "key_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_auth_tokens_team_id_teams_id_fk": {
+          "name": "api_auth_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_auth_tokens",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_auth_tokens_token_unique": {
+          "name": "api_auth_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Allow users to see API token entries they own": {
+          "name": "Allow users to see API token entries they own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "anon"
+          ],
+          "using": "is_allowed_apikey(((current_setting('request.headers'::text, true))::json ->> 'ethkey'::text), '{all,read}'::key_mode[])"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmarks": {
+      "name": "benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "benchmarks_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_count": {
+          "name": "transaction_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_instances": {
+      "name": "cloud_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cloud_instances_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_name": {
+          "name": "instance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_price": {
+          "name": "hourly_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_arch": {
+          "name": "cpu_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_effective_cores": {
+          "name": "cpu_effective_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_name": {
+          "name": "cpu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_arch": {
+          "name": "gpu_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_name": {
+          "name": "gpu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_memory": {
+          "name": "gpu_memory",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobo_name": {
+          "name": "mobo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_name": {
+          "name": "disk_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_space": {
+          "name": "disk_space",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cloud_instances_provider_id_cloud_providers_id_fk": {
+          "name": "cloud_instances_provider_id_cloud_providers_id_fk",
+          "tableFrom": "cloud_instances",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "tableTo": "cloud_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_instances_instance_name_unique": {
+          "name": "cloud_instances_instance_name_unique",
+          "columns": [
+            "instance_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_providers": {
+      "name": "cloud_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cloud_providers_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_providers_name_unique": {
+          "name": "cloud_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_benchmarks": {
+      "name": "cluster_benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cluster_benchmarks_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_id": {
+          "name": "benchmark_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cluster_benchmarks_cluster_id_clusters_id_fk": {
+          "name": "cluster_benchmarks_cluster_id_clusters_id_fk",
+          "tableFrom": "cluster_benchmarks",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_benchmarks_benchmark_id_benchmarks_id_fk": {
+          "name": "cluster_benchmarks_benchmark_id_benchmarks_id_fk",
+          "tableFrom": "cluster_benchmarks",
+          "columnsFrom": [
+            "benchmark_id"
+          ],
+          "tableTo": "benchmarks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_machines": {
+      "name": "cluster_machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cluster_machines_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cluster_version_id": {
+          "name": "cluster_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_count": {
+          "name": "machine_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_instance_id": {
+          "name": "cloud_instance_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_instance_count": {
+          "name": "cloud_instance_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cluster_machines_cluster_version_id_idx": {
+          "name": "cluster_machines_cluster_version_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cluster_machines_cloud_instance_id_idx": {
+          "name": "cluster_machines_cloud_instance_id_idx",
+          "columns": [
+            {
+              "expression": "cloud_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cluster_machines_cluster_version_id_cluster_versions_id_fk": {
+          "name": "cluster_machines_cluster_version_id_cluster_versions_id_fk",
+          "tableFrom": "cluster_machines",
+          "columnsFrom": [
+            "cluster_version_id"
+          ],
+          "tableTo": "cluster_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_machines_machine_id_machines_id_fk": {
+          "name": "cluster_machines_machine_id_machines_id_fk",
+          "tableFrom": "cluster_machines",
+          "columnsFrom": [
+            "machine_id"
+          ],
+          "tableTo": "machines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_machines_cloud_instance_id_cloud_instances_id_fk": {
+          "name": "cluster_machines_cloud_instance_id_cloud_instances_id_fk",
+          "tableFrom": "cluster_machines",
+          "columnsFrom": [
+            "cloud_instance_id"
+          ],
+          "tableTo": "cloud_instances",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_versions": {
+      "name": "cluster_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cluster_versions_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zkvm_version_id": {
+          "name": "zkvm_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cluster_versions_cluster_id_idx": {
+          "name": "cluster_versions_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cluster_versions_cluster_id_clusters_id_fk": {
+          "name": "cluster_versions_cluster_id_clusters_id_fk",
+          "tableFrom": "cluster_versions",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_versions_zkvm_version_id_zkvm_versions_id_fk": {
+          "name": "cluster_versions_zkvm_version_id_zkvm_versions_id_fk",
+          "tableFrom": "cluster_versions",
+          "columnsFrom": [
+            "zkvm_version_id"
+          ],
+          "tableTo": "zkvm_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardware": {
+          "name": "hardware",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_type": {
+          "name": "cycle_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_source": {
+          "name": "is_open_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_multi_machine": {
+          "name": "is_multi_machine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "software_link": {
+          "name": "software_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clusters_team_id_teams_id_fk": {
+          "name": "clusters_team_id_teams_id_fk",
+          "tableFrom": "clusters",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "machines_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cpu_model": {
+          "name": "cpu_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_memory_gb": {
+          "name": "gpu_memory_gb",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_size_gb": {
+          "name": "memory_size_gb",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_count": {
+          "name": "memory_count",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_size_gb": {
+          "name": "storage_size_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tera_flops": {
+          "name": "total_tera_flops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_between_machines": {
+          "name": "network_between_machines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "programs_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "verifier_id": {
+          "name": "verifier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_verifier_id_unique": {
+          "name": "programs_verifier_id_unique",
+          "columns": [
+            "verifier_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proofs": {
+      "name": "proofs",
+      "schema": "",
+      "columns": {
+        "proof_id": {
+          "name": "proof_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "proofs_proof_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proving_cycles": {
+          "name": "proving_cycles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "proved_timestamp": {
+          "name": "proved_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proving_timestamp": {
+          "name": "proving_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_timestamp": {
+          "name": "queued_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_version_id": {
+          "name": "cluster_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proving_time": {
+          "name": "proving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proofs_cluster_version_id_idx": {
+          "name": "proofs_cluster_version_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proofs_proved_timestamp_idx": {
+          "name": "proofs_proved_timestamp_idx",
+          "columns": [
+            {
+              "expression": "proved_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proofs_created_at_idx": {
+          "name": "proofs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proofs_block_number_blocks_block_number_fk": {
+          "name": "proofs_block_number_blocks_block_number_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "block_number"
+          ],
+          "tableTo": "blocks",
+          "columnsTo": [
+            "block_number"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "proofs_team_id_teams_id_fk": {
+          "name": "proofs_team_id_teams_id_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "proofs_cluster_version_id_cluster_versions_id_fk": {
+          "name": "proofs_cluster_version_id_cluster_versions_id_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "cluster_version_id"
+          ],
+          "tableTo": "cluster_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "proofs_program_id_programs_id_fk": {
+          "name": "proofs_program_id_programs_id_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "tableTo": "programs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_block_cluster_version": {
+          "name": "unique_block_cluster_version",
+          "columns": [
+            "block_number",
+            "cluster_version_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable updates for users with an api key": {
+          "name": "Enable updates for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "is_allowed_apikey(((current_setting('request.headers'::text, true))::json ->> 'ethkey'::text), '{all,write}'::key_mode[])"
+        },
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ]
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {
+        "proofs_proof_status_check": {
+          "name": "proofs_proof_status_check",
+          "value": "proof_status = ANY (ARRAY['queued'::text, 'proving'::text, 'proved'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.proofs_daily_stats": {
+      "name": "proofs_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "proofs_daily_stats_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost": {
+          "name": "avg_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_cost": {
+          "name": "median_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_latency": {
+          "name": "avg_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_latency": {
+          "name": "median_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "proofs_daily_stats_date_key": {
+          "name": "proofs_daily_stats_date_key",
+          "columns": [
+            "date"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prover_daily_stats": {
+      "name": "prover_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "prover_daily_stats_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost": {
+          "name": "avg_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_cost": {
+          "name": "median_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_latency": {
+          "name": "avg_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_latency": {
+          "name": "median_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prover_daily_stats_team_id_teams_id_fk": {
+          "name": "prover_daily_stats_team_id_teams_id_fk",
+          "tableFrom": "prover_daily_stats",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prover_daily_stats_date_team_key": {
+          "name": "prover_daily_stats_date_team_key",
+          "columns": [
+            "date",
+            "team_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recursive_root_proofs": {
+      "name": "recursive_root_proofs",
+      "schema": "",
+      "columns": {
+        "root_proof_id": {
+          "name": "root_proof_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "recursive_root_proofs_root_proof_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_proof": {
+          "name": "root_proof",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_proof_size": {
+          "name": "root_proof_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proof_size": {
+          "name": "total_proof_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recursive_root_proofs_block_number_blocks_block_number_fk": {
+          "name": "recursive_root_proofs_block_number_blocks_block_number_fk",
+          "tableFrom": "recursive_root_proofs",
+          "columnsFrom": [
+            "block_number"
+          ],
+          "tableTo": "blocks",
+          "columnsTo": [
+            "block_number"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "recursive_root_proofs_team_id_teams_id_fk": {
+          "name": "recursive_root_proofs_team_id_teams_id_fk",
+          "tableFrom": "recursive_root_proofs",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_quota_bytes": {
+          "name": "storage_quota_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_id_users_id_fk": {
+          "name": "teams_id_users_id_fk",
+          "tableFrom": "teams",
+          "columnsFrom": [
+            "id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_performance_metrics": {
+      "name": "zkvm_performance_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvm_performance_metrics_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_ms": {
+          "name": "verification_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_performance_metrics_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_performance_metrics_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_performance_metrics",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "tableTo": "zkvms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvm_performance_metrics_zkvm_id_unique": {
+          "name": "zkvm_performance_metrics_zkvm_id_unique",
+          "columns": [
+            "zkvm_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_security_metrics": {
+      "name": "zkvm_security_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvm_security_metrics_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_soundness": {
+          "name": "protocol_soundness",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "implementation_soundness": {
+          "name": "implementation_soundness",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evm_stf_bytecode": {
+          "name": "evm_stf_bytecode",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantum_security": {
+          "name": "quantum_security",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_target_bits": {
+          "name": "security_target_bits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_bounty_amount": {
+          "name": "max_bounty_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_setup": {
+          "name": "trusted_setup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_security_metrics_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_security_metrics_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_security_metrics",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "tableTo": "zkvms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvm_security_metrics_zkvm_id_unique": {
+          "name": "zkvm_security_metrics_zkvm_id_unique",
+          "columns": [
+            "zkvm_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_versions": {
+      "name": "zkvm_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvm_versions_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_versions_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_versions_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_versions",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "tableTo": "zkvms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvms": {
+      "name": "zkvms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvms_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isa": {
+          "name": "isa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continuations": {
+          "name": "continuations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dual_licenses": {
+          "name": "dual_licenses",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_open_source": {
+          "name": "is_open_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_proving_mainnet": {
+          "name": "is_proving_mainnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parallelizable_proving": {
+          "name": "parallelizable_proving",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "precompiles": {
+          "name": "precompiles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frontend": {
+          "name": "frontend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvms_team_id_teams_id_fk": {
+          "name": "zkvms_team_id_teams_id_fk",
+          "tableFrom": "zkvms",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvms_slug_unique": {
+          "name": "zkvms_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.key_mode": {
+      "name": "key_mode",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "all",
+        "upload"
+      ]
+    },
+    "public.severity_level": {
+      "name": "severity_level",
+      "schema": "public",
+      "values": [
+        "red",
+        "yellow",
+        "green"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "public.cluster_summary": {
+      "name": "cluster_summary",
+      "schema": "public",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_nickname": {
+          "name": "cluster_nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT c.id as cluster_id,\n      c.nickname as cluster_nickname,\n      c.team_id,\n      COALESCE(sum(cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) / NULLIF(count(p.proof_id), 0)::double precision, 0::double precision) AS avg_cost_per_proof,\n      avg(p.proving_time) AS avg_proving_time\n    FROM clusters c\n    LEFT JOIN cluster_versions cv ON c.id = cv.cluster_id\n    LEFT JOIN proofs p ON cv.id = p.cluster_version_id AND p.proof_status = 'proved'::text\n    LEFT JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    LEFT JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    GROUP BY c.id",
+      "materialized": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "isExisting": false
+    },
+    "public.recent_summary": {
+      "name": "recent_summary",
+      "schema": "public",
+      "columns": {
+        "total_proven_blocks": {
+          "name": "total_proven_blocks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_cost_per_proof": {
+          "name": "median_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_proving_time": {
+          "name": "median_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT count(DISTINCT b.block_number) AS total_proven_blocks,\n      -- Calculate average cost per proof\n      COALESCE(avg(cm.cloud_instance_count::double precision * ci.hourly_price * p.proving_time::double precision / (1000.0 * 60::numeric * 60::numeric)::double precision), 0::numeric::double precision) AS avg_cost_per_proof,\n      -- Calculate median cost per proof\n      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY cm.cloud_instance_count::double precision * ci.hourly_price * p.proving_time::double precision / (1000.0 * 60::numeric * 60::numeric)::double precision), 0::numeric::double precision) AS median_cost_per_proof,\n      -- Calculate average latency\n      COALESCE(avg(p.proving_time), 0::numeric) AS avg_proving_time,\n      -- Calculate median latency\n      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY p.proving_time), 0::numeric) AS median_proving_time\n    FROM blocks b\n    INNER JOIN proofs p ON b.block_number = p.block_number AND p.proof_status = 'proved'::text\n    INNER JOIN cluster_versions cv ON p.cluster_version_id = cv.id\n    INNER JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    INNER JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    WHERE b.\"timestamp\" >= (now() - '30 days'::interval)",
+      "materialized": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "isExisting": false
+    },
+    "public.teams_summary": {
+      "name": "teams_summary",
+      "schema": "public",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof_multi": {
+          "name": "avg_cost_per_proof_multi",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time_multi": {
+          "name": "avg_proving_time_multi",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs_multi": {
+          "name": "total_proofs_multi",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof_single": {
+          "name": "avg_cost_per_proof_single",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time_single": {
+          "name": "avg_proving_time_single",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs_single": {
+          "name": "total_proofs_single",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT t.id as team_id,\n      t.name as team_name,\n      t.logo_url,\n      -- All proofs\n      COALESCE(sum(cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) / NULLIF(count(p.proof_id), 0)::double precision, 0::double precision) AS avg_cost_per_proof,\n      COALESCE(avg(p.proving_time), 0::numeric) AS avg_proving_time,\n      count(p.proof_id) AS total_proofs,\n      -- Multi-machine proofs\n      COALESCE(sum(CASE WHEN c.is_multi_machine THEN (cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) ELSE 0 END) / NULLIF(sum(CASE WHEN c.is_multi_machine THEN 1 ELSE 0 END), 0)::double precision, 0::double precision) AS avg_cost_per_proof_multi,\n      COALESCE(avg(CASE WHEN c.is_multi_machine THEN p.proving_time ELSE NULL END), 0::numeric) AS avg_proving_time_multi,\n      sum(CASE WHEN c.is_multi_machine THEN 1 ELSE 0 END) AS total_proofs_multi,\n      -- Single-machine proofs\n      COALESCE(sum(CASE WHEN NOT c.is_multi_machine THEN (cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) ELSE 0 END) / NULLIF(sum(CASE WHEN NOT c.is_multi_machine THEN 1 ELSE 0 END), 0)::double precision, 0::double precision) AS avg_cost_per_proof_single,\n      COALESCE(avg(CASE WHEN NOT c.is_multi_machine THEN p.proving_time ELSE NULL END), 0::numeric) AS avg_proving_time_single,\n      sum(CASE WHEN NOT c.is_multi_machine THEN 1 ELSE 0 END) AS total_proofs_single\n    FROM teams t\n    LEFT JOIN proofs p ON t.id = p.team_id AND p.proof_status = 'proved'::text\n    LEFT JOIN cluster_versions cv ON p.cluster_version_id = cv.id\n    LEFT JOIN clusters c ON cv.cluster_id = c.id\n    LEFT JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    LEFT JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    GROUP BY t.id",
+      "materialized": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1753128679795,
       "tag": "0023_remove-vendors",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1754503525807,
+      "tag": "0024_proof-monitoring-cron",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Implements a daily cron job (1pm utc) that monitors proof submissions from the past 24 hours and sends TG alerts for any missing proofs, grouped by team/cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily automated proof-monitoring with scheduled alerts at 14:00 UTC: internal summary plus per-team Telegram alerts (clickable cluster links); alerts only sent when bot token and team chat IDs are configured.
  * Per-team chat ID support to route alerts; messages use MarkdownV2-safe formatting and handle missing configuration gracefully.

* **Chores**
  * Database schema/migration updates (new tables, views, enums) and migration metadata added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->