### PR TITLE
feat: cluster disclaimer banner

### DIFF
--- a/app/clusters/[clusterId]/page.tsx
+++ b/app/clusters/[clusterId]/page.tsx
@@ -25,6 +25,7 @@ import { hasPhysicalMachines, isMultiMachineCluster } from "@/lib/clusters"
 import { getMetadata } from "@/lib/metadata"
 import { formatUsd } from "@/lib/number"
 import { prettyMs } from "@/lib/time"
+import { isUnverifiableZkvm } from "@/lib/zkvms"
 
 export type ClusterDetailsPageProps = {
   params: Promise<{ clusterId: string }>
@@ -146,6 +147,14 @@ export default async function ClusterDetailsPage({
       <Card className="mx-auto w-fit">
         <KPIs items={clusterSummaryItems} layout="flipped" />
       </Card>
+
+      {/* TODO: Track this metric */}
+      {isUnverifiableZkvm(zkvm.slug) && (
+        <aside className="flex items-center justify-center gap-2 rounded border border-level-worst bg-background-accent px-6 py-4 text-center text-level-worst">
+          disclaimer: this cluster is submitting proofs that cannot be
+          independently verified
+        </aside>
+      )}
 
       {cluster.software_link && (
         <aside className="flex items-center justify-center gap-2 rounded bg-background-accent px-6 py-4 text-center">

--- a/lib/zkvms.ts
+++ b/lib/zkvms.ts
@@ -74,3 +74,8 @@ export const getSlices = (items: SoftwareDetailItem[]) =>
   items
     .sort((a, b) => a.position - b.position)
     .map((item) => ({ level: item.severity })) as Slices
+
+export const UNVERIFIABLE_ZKVM_SLUGS = new Set<string>(["sp1-hypercube"])
+export function isUnverifiableZkvm(slug: string): boolean {
+  return UNVERIFIABLE_ZKVM_SLUGS.has(slug)
+}


### PR DESCRIPTION
This PR adds a warning banner to any cluster using `SP1 Hypercube` until their verifier is made public with the release. We will also add this disclaimer to any other zkVMs when their proofs cannot be independently verified. We are currently working on in-browser verification for all zkVMs on Ethproofs.

<img width="1510" height="826" alt="Screenshot 2025-08-10 at 9 16 44 AM" src="https://github.com/user-attachments/assets/efaca2e7-e044-4c75-b5d4-0886004a3b32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Cluster Details: Display a highlighted disclaimer for clusters running “SP1 Hypercube” zkVM, stating submitted proofs cannot be independently verified.
  - The notice is shown after the KPIs section (render-time only) and appears only when applicable; it does not change functionality elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->