### PR TITLE
fix: use dynamic imports for wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ robots.txt
 # cursor
 .cursorrules
 .cursor
+
+# Local Netlify folder
+.netlify


### PR DESCRIPTION
This fixes an issue with loading WASM when deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Proof verification now loads its verification engine on demand, reducing initial load time and improving reliability during initialization and verification; no changes to user-facing APIs or workflows.

* **Chores**
  * Project ignore settings updated to exclude the local Netlify folder from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->