### PR TITLE
refactor(telemetry): remove redundant request.body check in getRequestBody

### DIFF
--- a/lib/middleware/with-telemetry.ts
+++ b/lib/middleware/with-telemetry.ts
@@ -45,17 +45,15 @@ const getRequestBody = async (request: Request) => {
   }
 
   let body: string | undefined
-  if (request.body) {
+  try {
+    const clonedRequest = request.clone()
     try {
-      const clonedRequest = request.clone()
-      try {
-        body = await clonedRequest.json()
-      } catch {
-        body = await clonedRequest.text()
-      }
-    } catch (error) {
-      console.warn("Could not parse request body:", error)
+      body = await clonedRequest.json()
+    } catch {
+      body = await clonedRequest.text()
     }
+  } catch (error) {
+    console.warn("Could not parse request body:", error)
   }
 
   return body


### PR DESCRIPTION
- Remove duplicate request.body truthy check after early return in getRequestBody within lib/middleware/with-telemetry.ts
- Preserve existing parsing logic; no runtime behavior changes
- Improves readability and simplifies control flow