### PR TITLE
Alert monitor patches

### DIFF
--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -180,13 +180,13 @@ BEGIN
           AND cluster_id_suffix = cluster.cluster_id_suffix;
 
         IF array_length(missing_blocks, 1) > 3 THEN
-            display_blocks := missing_blocks[1] || ', ' || missing_blocks[2] || ', ' || missing_blocks[3] || ' +' || (array_length(missing_blocks, 1) - 3) || ' more';
+            display_blocks := '`' || missing_blocks[1] || '`, `' || missing_blocks[2] || '`, `' || missing_blocks[3] || '` +' || (array_length(missing_blocks, 1) - 3) || ' more';
         ELSE
-            display_blocks := array_to_string(missing_blocks, ', ');
+            display_blocks := '`' || array_to_string(missing_blocks, '`, `') || '`';
         END IF;
 
         message_text := message_text || E'▪️ *' || escape_markdown_v2(cluster.team_name) || '* \- ' || escape_markdown_v2(cluster.cluster_nickname) || ' \(…' || escape_markdown_v2(cluster.cluster_id_suffix) || E'\\)\n';
-        message_text := message_text || E'   Missing proofs for blocks: `' || display_blocks || E'`\n\n';
+        message_text := message_text || E'   Missing proofs for blocks: ' || display_blocks || E'\n\n';
     END LOOP;
     
     -- Send to internal Telegram chat
@@ -256,9 +256,9 @@ BEGIN
               AND cluster_id = cluster_record.cluster_id;
             
             IF array_length(missing_blocks, 1) > 3 THEN
-                display_blocks := missing_blocks[1] || ', ' || missing_blocks[2] || ', ' || missing_blocks[3] || ' +' || (array_length(missing_blocks, 1) - 3) || ' more';
+                display_blocks := '`' || missing_blocks[1] || '`, `' || missing_blocks[2] || '`, `' || missing_blocks[3] || '` +' || (array_length(missing_blocks, 1) - 3) || ' more';
             ELSE
-                display_blocks := array_to_string(missing_blocks, ', ');
+                display_blocks := '`' || array_to_string(missing_blocks, '`, `') || '`';
             END IF;
             
             IF cluster_count = 1 THEN
@@ -269,7 +269,7 @@ BEGIN
             cluster_link := escape_markdown_v2(cluster_link);
 
             message_text := message_text || E' • [*' || cluster_record.cluster_nickname || '* \(…' || cluster_record.cluster_id_suffix || '\)](' || cluster_link || E')\n' ||
-                           E'   Missing blocks: `' || display_blocks || E'`\n';
+                           E'   Missing blocks: ' || display_blocks || E'\n';
             
             IF cluster_count < (SELECT COUNT(DISTINCT cluster_id) FROM missing_proofs_temp WHERE team_id = team_record.team_id) THEN
                 message_text := message_text || E'\n';

--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -176,9 +176,7 @@ BEGIN
         -- Get missing blocks for this team/cluster combination
         SELECT array_agg(block_number ORDER BY block_number) INTO missing_blocks
         FROM missing_proofs_temp
-        WHERE team_name = cluster.team_name 
-          AND cluster_nickname = cluster.cluster_nickname
-          AND cluster_id_suffix = cluster.cluster_id_suffix;
+        WHERE cluster_id = cluster.cluster_id;
 
         IF array_length(missing_blocks, 1) > 3 THEN
             display_blocks := '`' || missing_blocks[1] || '`, `' || missing_blocks[2] || '`, `' || missing_blocks[3] || '` +' || (array_length(missing_blocks, 1) - 3) || ' more';

--- a/supabase/migrations/0024_proof-monitoring-cron.sql
+++ b/supabase/migrations/0024_proof-monitoring-cron.sql
@@ -147,6 +147,7 @@ DECLARE
     telegram_chat_id TEXT;
     missing_blocks TEXT[];
     display_blocks TEXT;
+    cluster_link TEXT;
 BEGIN
     -- Get Telegram configuration
     telegram_bot_token := get_telegram_bot_token();
@@ -168,7 +169,7 @@ BEGIN
     message_text := E'🚨 *Missing Proof Alert*\n\nFound ' || missing_count || E' missing proofs on ' || escape_markdown_v2(to_char(CURRENT_DATE - INTERVAL '1 day', 'YYYY-MM-DD')) || E':\n\n';
     
     FOR cluster IN
-        SELECT DISTINCT team_name, cluster_nickname, cluster_id_suffix
+        SELECT DISTINCT team_name, cluster_nickname, cluster_id_suffix, cluster_id
         FROM missing_proofs_temp
         ORDER BY team_name, cluster_nickname
     LOOP
@@ -185,7 +186,10 @@ BEGIN
             display_blocks := '`' || array_to_string(missing_blocks, '`, `') || '`';
         END IF;
 
-        message_text := message_text || E'▪️ *' || escape_markdown_v2(cluster.team_name) || '* \- ' || escape_markdown_v2(cluster.cluster_nickname) || ' \(…' || escape_markdown_v2(cluster.cluster_id_suffix) || E'\\)\n';
+        cluster_link := E'https://ethproofs.com/cluster/' || cluster.cluster_id;
+        cluster_link := escape_markdown_v2(cluster_link);
+
+        message_text := message_text || E'▪️ *' || escape_markdown_v2(cluster.team_name) || '* \- [' || escape_markdown_v2(cluster.cluster_nickname) || ' \(…' || escape_markdown_v2(cluster.cluster_id_suffix) || E'\\)\](' || cluster_link || E')\n';
         message_text := message_text || E'   Missing proofs for blocks: ' || display_blocks || E'\n\n';
     END LOOP;
     


### PR DESCRIPTION
- improve md formatting for block numbers
- add a link for each cluster name in the summary alert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts now include clickable per-cluster links to dedicated cluster pages, using the cluster nickname as the link text.
  * Improved “Missing blocks” display: block numbers are shown in monospace; longer lists show a concise preview (first three) with “+ N more,” otherwise the full list.
  * Unified, cleaner message formatting across internal summaries and team alerts for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->