### PR TITLE
feat: add hover cursor pointer to theme switch buttons

### DIFF
--- a/components/header/ThemeSwitch.tsx
+++ b/components/header/ThemeSwitch.tsx
@@ -66,7 +66,6 @@ const ThemeSwitch = () => {
             onClick={() => setTheme(item.id)}
             className={cn(
               "rounded-none",
-              "hover:cursor-pointer",
               "first-of-type:rounded-t-[calc(1rem_-_1px)]",
               "last-of-type:rounded-b-[calc(1rem_-_1px)]",
               theme === item.id && "bg-background-active"

--- a/components/header/ThemeSwitch.tsx
+++ b/components/header/ThemeSwitch.tsx
@@ -66,6 +66,7 @@ const ThemeSwitch = () => {
             onClick={() => setTheme(item.id)}
             className={cn(
               "rounded-none",
+              "hover:cursor-pointer",
               "first-of-type:rounded-t-[calc(1rem_-_1px)]",
               "last-of-type:rounded-b-[calc(1rem_-_1px)]",
               theme === item.id && "bg-background-active"

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -102,7 +102,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default hover:cursor-pointer select-none items-center rounded py-1 pe-2 ps-8 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default hover:cursor-pointer select-none items-center rounded py-1 pe-2 ps-8 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -131,7 +131,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default hover:cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default hover:cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -86,7 +86,7 @@ const DropdownMenuItem = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded-none border-b border-b-primary-border px-2 py-px last-of-type:border-b-transparent",
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default hover:cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-background-highlight data-[state=open]:bg-background-highlight [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default hover:cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-background-highlight data-[state=open]:bg-background-highlight [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -102,7 +102,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded py-1 pe-2 ps-8 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default hover:cursor-pointer select-none items-center rounded py-1 pe-2 ps-8 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -131,7 +131,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default hover:cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-background-highlight focus:text-body data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}


### PR DESCRIPTION
Add hover:cursor-pointer class to theme switch buttons for better UX
Improves user experience by showing pointer cursor on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Dropdown menu items now show a pointer cursor on hover, improving affordance and interactivity cues.
  * Disabled dropdown checkboxes explicitly show a not-allowed cursor to indicate inactivity.
  * No functional, API, or behavior changes beyond cursor/styling adjustments.
  * Enhances consistency with other clickable elements and improves discoverability of interactive items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->