### PR TITLE
chore(stats): normalize and clamp days param to avoid invalid ranges

### DIFF
--- a/app/api/stats/proofs/daily/route.ts
+++ b/app/api/stats/proofs/daily/route.ts
@@ -8,7 +8,10 @@ const MAX_DAYS = Math.max(...CHART_RANGES)
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
-  const days = Math.min(Number(searchParams.get("days")), MAX_DAYS)
+  const rawDays = Number(searchParams.get("days"))
+  const defaultDays = Math.max(...CHART_RANGES)
+  const parsedDays = Number.isFinite(rawDays) ? Math.floor(rawDays) : defaultDays
+  const days = Math.max(0, Math.min(parsedDays, MAX_DAYS))
 
   const data = await fetchProofsDailyStats(days)
   return NextResponse.json(data)

--- a/lib/api/stats.ts
+++ b/lib/api/stats.ts
@@ -17,8 +17,9 @@ import {
  * @param days - Number of days to include (e.g., 7, 30, 90, 365)
  */
 export const fetchProofsDailyStats = async (days: number) => {
+  const safeDays = Number.isFinite(days) ? Math.max(0, Math.floor(days)) : 0
   const endDate = new Date()
-  const startDate = startOfDay(addDays(endDate, -days))
+  const startDate = startOfDay(addDays(endDate, -safeDays))
 
   return db.query.proofsDailyStats.findMany({
     where: (stats, { and, gte, lte }) =>
@@ -36,8 +37,9 @@ export const fetchProofsDailyStats = async (days: number) => {
  * @param days - Number of days to include (e.g., 7, 30, 90, 365)
  */
 export const fetchProverDailyStats = async (teamId: string, days: number) => {
+  const safeDays = Number.isFinite(days) ? Math.max(0, Math.floor(days)) : 0
   const endDate = new Date()
-  const startDate = startOfDay(addDays(endDate, -days))
+  const startDate = startOfDay(addDays(endDate, -safeDays))
 
   return db.query.proverDailyStats.findMany({
     where: (stats, { and, eq, gte, lte }) =>


### PR DESCRIPTION
- Add robust parsing and clamping of days query param in /api/stats/proofs/daily to [0, MAX_DAYS], with sensible default when NaN.
- Add defensive normalization in fetchProofsDailyStats and fetchProverDailyStats to ensure non-negative integer days, preventing inverted or invalid date ranges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of the "days" parameter across stats endpoints to prevent invalid ranges and NaN results.
  - Inputs are now sanitized: non-integers are floored, non-finite/invalid values fall back to a safe default, and negatives are clamped.
  - Date windows use the sanitized days value, ensuring consistent charts and stable behavior while preserving existing API signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->