### PR TITLE
feat: zisk verifier

### DIFF
--- a/components/proof-buttons/VerifyButton.tsx
+++ b/components/proof-buttons/VerifyButton.tsx
@@ -30,7 +30,7 @@ export type ProofForDownload = Required<
   team: Required<Pick<Team, "name" | "slug">>
 }
 
-const VERIFIABLE_PROVER_TEAM_SLUGS = new Set<string>(["brevis", "zkm"])
+const VERIFIABLE_PROVER_TEAM_SLUGS = new Set<string>(["brevis", "zkm", "zisk"])
 function isVerifiableProverTeam(slug: string): boolean {
   return VERIFIABLE_PROVER_TEAM_SLUGS.has(slug)
 }

--- a/components/proof-buttons/useVerifyProof.tsx
+++ b/components/proof-buttons/useVerifyProof.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 
 import { usePicoVerifier } from "./verifier-hooks/usePicoVerifier"
 import { useZirenVerifier } from "./verifier-hooks/useZirenVerifier"
+import { useZiskVerifier } from "./verifier-hooks/useZiskVerifier"
 
 export interface VerificationResult {
   error?: string
@@ -15,6 +16,7 @@ export function useVerifyProof(prover: string) {
   const [verifyTime, setVerifyTime] = useState("")
   const verifyPicoProof = usePicoVerifier(prover === "brevis")
   const verifyZirenProof = useZirenVerifier(prover === "zkm")
+  const verifyZiskProof = useZiskVerifier(prover === "zisk")
 
   const verifyProof = useCallback(
     async (
@@ -28,6 +30,8 @@ export function useVerifyProof(prover: string) {
           result = verifyPicoProof(proofBytes, vkBytes)
         } else if (prover === "zkm") {
           result = verifyZirenProof(proofBytes, vkBytes)
+        } else if (prover === "zisk") {
+          result = verifyZiskProof(proofBytes, vkBytes)
         } else {
           result = { isValid: false, error: "Proof cannot be verified" }
         }
@@ -41,7 +45,7 @@ export function useVerifyProof(prover: string) {
         }
       }
     },
-    [prover, verifyPicoProof, verifyZirenProof]
+    [prover, verifyPicoProof, verifyZirenProof, verifyZiskProof]
   )
 
   return {

--- a/components/proof-buttons/verifier-hooks/useZiskVerifier.tsx
+++ b/components/proof-buttons/verifier-hooks/useZiskVerifier.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+export function useZiskVerifier(active: boolean = false) {
+  const [wasmModule, setWasmModule] = useState<
+    typeof import("@ethproofs/zisk-wasm-stark-verifier") | null
+  >(null)
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+
+    async function initializeWasm() {
+      if (!active) return
+      try {
+        console.log("[Zisk] Initializing WASM module...")
+        const loadedModule = await import("@ethproofs/zisk-wasm-stark-verifier")
+        loadedModule.main()
+
+        if (mounted) {
+          setWasmModule(loadedModule)
+          setIsInitialized(true)
+          console.log("[Zisk] WASM module initialized")
+        }
+      } catch (error) {
+        console.error("[Zisk] WASM initialization failed:", error)
+        if (mounted) {
+          console.error(
+            error instanceof Error ? error.message : "Unknown error"
+          )
+        }
+      }
+    }
+
+    initializeWasm()
+
+    return () => {
+      mounted = false
+    }
+  }, [active])
+
+  return useCallback(
+    (proofBytes: Uint8Array, vkBytes: Uint8Array) => {
+      if (!wasmModule || !isInitialized) {
+        return { isValid: false, error: "[Zisk] WASM module not initialized" }
+      }
+      try {
+        const result = wasmModule.verify_stark(proofBytes, vkBytes)
+        return { isValid: result }
+      } catch (err) {
+        console.error("[Zisk] verify_stark failed:", err)
+        return {
+          isValid: false,
+          error: err instanceof Error ? err.message : "Zisk verifier error",
+        }
+      }
+    },
+    [wasmModule, isInitialized]
+  )
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ethproofs/pico-wasm-stark-verifier": "^0.1.4",
     "@ethproofs/ziren-wasm-stark-verifier": "^0.1.4",
+    "@ethproofs/zisk-wasm-stark-verifier": "^0.1.0",
     "@radix-ui/react-accordion": "1.2.10",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-dropdown-menu": "^2.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@ethproofs/ziren-wasm-stark-verifier':
         specifier: ^0.1.4
         version: 0.1.4
+      '@ethproofs/zisk-wasm-stark-verifier':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@radix-ui/react-accordion':
         specifier: 1.2.10
         version: 1.2.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1273,6 +1276,10 @@ packages:
 
   '@ethproofs/ziren-wasm-stark-verifier@0.1.4':
     resolution: {integrity: sha512-NOzM6XdztEE/97ICEdDOAEIAG1fDvb515UDpGmAD9BPyvn+d1gQWxMw8s275u6MazBw2XPaFA9L8BJkB8zVrwA==}
+    engines: {node: '>=16.0.0'}
+
+  '@ethproofs/zisk-wasm-stark-verifier@0.1.0':
+    resolution: {integrity: sha512-HIKbojmGupfaePEN4LBea9OT0QAFbCIvzpTIGFo8X1Xr44VzQP5QA0IMaVPtfIXWRDjW3XpFQCwxYurEYhd58g==}
     engines: {node: '>=16.0.0'}
 
   '@faker-js/faker@8.4.1':
@@ -6878,6 +6885,8 @@ snapshots:
   '@ethproofs/pico-wasm-stark-verifier@0.1.4': {}
 
   '@ethproofs/ziren-wasm-stark-verifier@0.1.4': {}
+
+  '@ethproofs/zisk-wasm-stark-verifier@0.1.0': {}
 
   '@faker-js/faker@8.4.1': {}
 


### PR DESCRIPTION
This PR adds ZisK in-browser verification to Ethproofs using:
https://www.npmjs.com/package/@ethproofs/zisk-wasm-stark-verifier

https://github.com/user-attachments/assets/ae2cdb4a-aabb-4b79-9cc6-3168d202887e

