### PR TITLE
fix: type error from request body reads

### DIFF
--- a/app/api/v0/proofs/proving/route.ts
+++ b/app/api/v0/proofs/proving/route.ts
@@ -10,11 +10,10 @@ import { withAuth } from "@/lib/middleware/with-auth"
 import { provingProofSchema } from "@/lib/zod/schemas/proof"
 
 // TODO:TEAM - refactor code to use baseProofHandler and abstract out the logic
-
 export const POST = withAuth(async ({ request, user, timestamp }) => {
   const payload = await request.json()
 
-  // validate payload schema
+  // Validate payload schema
   let proofPayload
   try {
     proofPayload = provingProofSchema.parse(payload)
@@ -33,7 +32,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
 
   const { block_number, cluster_id } = proofPayload
 
-  // validate block_number exists
+  // Validate block_number exists
   console.log("validating block_number", block_number)
   const block = await db.query.blocks.findFirst({
     columns: {
@@ -42,7 +41,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     where: (blocks, { eq }) => eq(blocks.block_number, block_number),
   })
 
-  // if block is new (not in db), fetch block data from block explorer and create block record
+  // If block is new (not in db), fetch block data from block explorer and create block record
   if (!block) {
     console.log("block not found, fetching block data", block_number)
     let blockData
@@ -56,7 +55,6 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     }
 
     try {
-      // create block
       console.log("creating block", block_number)
       await db
         .insert(blocks)
@@ -74,7 +72,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     }
   }
 
-  // get cluster uuid from cluster_id
+  // Get cluster uuid from cluster_id
   const cluster = await db.query.clusters.findFirst({
     columns: {
       id: true,
@@ -88,7 +86,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     return new Response("Cluster not found", { status: 404 })
   }
 
-  // get the last cluster_version_id from cluster_id
+  // Get the last cluster_version_id from cluster_id
   const clusterVersion = await db.query.clusterVersions.findFirst({
     columns: {
       id: true,
@@ -103,7 +101,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
     return new Response("Cluster version not found", { status: 404 })
   }
 
-  // add proof
+  // Add proof
   const dataToInsert = {
     ...proofPayload,
     block_number,
@@ -128,16 +126,16 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
       })
       .returning({ proof_id: proofs.proof_id })
 
-    // invalidate cache
+    // Invalidate cache
     revalidateTag(TAGS.PROOFS)
     revalidateTag(TAGS.BLOCKS)
     revalidateTag(`cluster-${cluster.id}`)
     revalidateTag(`block-${block_number}`)
 
-    // return the generated proof_id
+    // Return the generated proof_id
     return Response.json(proof)
   } catch (error) {
     console.error("error adding proof", error)
-    return new Response("Internal server error", { status: 500 })
+    return new Response("Error adding proving proof", { status: 500 })
   }
 })


### PR DESCRIPTION
We are seeing quite a lot of these TypeErrors in the app logs. I'm hoping cloning the request upfront might fix the issue. Also, I have tried to improve our telemetry middleware and 500 error handling to provide more feedback. I believe the 500s are being caused by our fetch for block data.

<img width="1397" height="146" alt="Screenshot 2025-09-11 at 7 31 40 PM" src="https://github.com/user-attachments/assets/76b67eff-7b7e-49a0-91ca-bf3d84c80911" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry can be configured with sampling and now emits pre-timeout warnings to improve observability without blocking requests.
  * External payload validation now returns clear 400 responses for invalid requests.

* **Bug Fixes**
  * More reliable telemetry sending and safer non-blocking telemetry handling to reduce crashes/timeouts.
  * Improved error responses for proof-related endpoints and added retry logic when fetching external block data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->