### PR TITLE
chore: fix typo in the type name

### DIFF
--- a/components/NotFoundTemplate.tsx
+++ b/components/NotFoundTemplate.tsx
@@ -2,7 +2,7 @@ import { ButtonLink } from "./ui/button"
 import { HeroSection } from "./ui/hero"
 import { type LinkProps } from "./ui/link"
 
-type NotFoundsTemplateProps = Partial<
+type NotFoundTemplateProps = Partial<
   Pick<React.HTMLAttributes<HTMLDivElement>, "children"> &
     Pick<LinkProps, "href"> & {
       icon: React.ReactNode
@@ -15,7 +15,7 @@ const NotFoundTemplate = ({
   href = "/",
   label = "page",
   icon,
-}: NotFoundsTemplateProps) => {
+}: NotFoundTemplateProps) => {
   return (
     <>
       <HeroSection className="space-y-4">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized an internal prop type name for the NotFound template component to correct a typo, improving consistency and maintainability. No runtime or UI changes.

* **Chores**
  * Updated the component’s parameter typing to use the corrected type name and aligned references. Behavior, layout, and accessibility remain unchanged; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->