### PR TITLE
fix(blocks): detect hash before numeric and allow hash in /blocks/[block]

### DIFF
--- a/app/blocks/[block]/page.tsx
+++ b/app/blocks/[block]/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({
 }: BlockDetailsPageProps): Promise<Metadata> {
   const { block } = await params
 
-  if (isNaN(+block)) throw new Error()
+  if (!isBlockHash(block) && isNaN(+block)) throw new Error()
 
   const blockData = await fetchBlock(
     isBlockHash(block)
@@ -77,7 +77,7 @@ export default async function BlockDetailsPage({
 }: BlockDetailsPageProps) {
   const blockNumber = (await params).block
 
-  if (isNaN(+blockNumber)) throw new Error()
+  if (!isBlockHash(blockNumber) && isNaN(+blockNumber)) throw new Error()
 
   const block = await fetchBlock(
     isBlockHash(blockNumber)

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -56,11 +56,11 @@ export const fetchBlockData = async (block_number: number, maxRetries = 3) => {
 export const getBlockValueType = (
   block: string
 ): keyof Pick<Block, "hash" | "block_number"> | null => {
-  if (isNaN(+block)) return null
-
   if (isBlockHash(block)) return "hash"
 
-  return "block_number"
+  if (!isNaN(+block)) return "block_number"
+
+  return null
 }
 
 export const isBlockHash = (block: string) => {


### PR DESCRIPTION
Reordered getBlockValueType to check isBlockHash first, then numeric, else null. This matches the function’s docstring, the search flow that routes to /blocks/{hash}, error copy mentioning “number or hash,” and OpenAPI allowing both integer and 64-hex string. Updated /blocks/[block] guards to validate “hash OR integer” so navigating by hash works and not-found displays correctly instead of NaN.