### PR TITLE
refactor: proof requests

### DIFF
--- a/app/api/v0/proofs/proved/route.ts
+++ b/app/api/v0/proofs/proved/route.ts
@@ -6,7 +6,7 @@ import { TAGS } from "@/lib/constants"
 
 import { db } from "@/db"
 import { clusters, programs, proofs } from "@/db/schema"
-import { findOrCreateBlock } from "@/lib/api/blocks"
+import { updateBlock } from "@/lib/api/blocks"
 import { uploadProofBinary } from "@/lib/api/proof-binaries"
 import { isStorageQuotaExceeded } from "@/lib/api/storage"
 import { getTeam } from "@/lib/api/teams"
@@ -67,7 +67,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
   }
 
   try {
-    const block = await findOrCreateBlock(block_number)
+    const block = await updateBlock(block_number)
     console.log(`[Proved] Block ${block} found by team:`, teamId)
   } catch (error) {
     console.error(

--- a/app/blocks/[block]/page.tsx
+++ b/app/blocks/[block]/page.tsx
@@ -1,19 +1,10 @@
-import {
-  BookOpen,
-  Box,
-  CircleDollarSign,
-  Clock,
-  Coins,
-  Cpu,
-  Hourglass,
-  Layers,
-  Timer,
-} from "lucide-react"
+import { Box, Clock, Coins, Cpu, Hourglass, Layers, Timer } from "lucide-react"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import BasicTabs from "@/components/BasicTabs"
 import CopyButton from "@/components/CopyButton"
+import Null from "@/components/Null"
 import DownloadAllButton from "@/components/proof-buttons/DownloadAllButton"
 import ProofList from "@/components/ProofList"
 import ProofStatus, { ProofStatusInfo } from "@/components/ProofStatus"
@@ -141,7 +132,7 @@ export default async function BlockDetailsPage({
             <div className="truncate font-sans text-sm font-normal text-body-secondary">
               {hash}
             </div>
-            <CopyButton message={hash} />
+            {hash ? <CopyButton message={hash} /> : <Null />}
           </div>
         </div>
       </HeroTitle>
@@ -151,7 +142,7 @@ export default async function BlockDetailsPage({
           <HeroItemLabel>
             <Clock className="size-4" /> timestamp
           </HeroItemLabel>
-          <Timestamp>{timestamp}</Timestamp>
+          {timestamp ? <Timestamp>{timestamp}</Timestamp> : <Null />}
         </HeroItem>
 
         <HeroItem className="row-span-2 grid grid-rows-subgrid place-items-center gap-y-1">
@@ -159,7 +150,11 @@ export default async function BlockDetailsPage({
             <Cpu className="size-4" /> gas used
           </HeroItemLabel>
           <p className="font-mono tracking-wide">
-            <HidePunctuation>{formatNumber(gas_used)}</HidePunctuation>
+            {gas_used ? (
+              <HidePunctuation>{formatNumber(gas_used)}</HidePunctuation>
+            ) : (
+              <Null />
+            )}
           </p>
         </HeroItem>
 
@@ -168,9 +163,13 @@ export default async function BlockDetailsPage({
             <Layers className="size-4" /> slot
           </HeroItemLabel>
           <p className="font-mono tracking-wide">
-            <HidePunctuation>
-              {formatNumber(timestampToSlot(timestamp))}
-            </HidePunctuation>
+            {timestamp ? (
+              <HidePunctuation>
+                {formatNumber(timestampToSlot(timestamp))}
+              </HidePunctuation>
+            ) : (
+              <Null />
+            )}
           </p>
         </HeroItem>
 
@@ -179,9 +178,13 @@ export default async function BlockDetailsPage({
             <Hourglass className="size-4" /> epoch
           </HeroItemLabel>
           <p className="font-mono tracking-wide">
-            <HidePunctuation>
-              {formatNumber(timestampToEpoch(timestamp))}
-            </HidePunctuation>
+            {timestamp ? (
+              <HidePunctuation>
+                {formatNumber(timestampToEpoch(timestamp))}
+              </HidePunctuation>
+            ) : (
+              <Null />
+            )}
           </p>
         </HeroItem>
       </section>

--- a/components/BlocksTable/columns.tsx
+++ b/components/BlocksTable/columns.tsx
@@ -193,8 +193,6 @@ export const columns: ColumnDef<Block>[] = [
       const proofs = cell.getValue() as ProofWithCluster[]
       const timestamp = row.original.timestamp
 
-      if (!timestamp) return <Null />
-
       const totalTTPStats = getTotalTTPStats(proofs, timestamp)
       const proofsPerStatusCount = getProofsPerStatusCount(proofs)
 

--- a/components/ClusterProofRow.tsx
+++ b/components/ClusterProofRow.tsx
@@ -37,9 +37,10 @@ export type ClusterProofRowProps = {
 
 export const ClusterProofRow = ({ proof }: ClusterProofRowProps) => {
   const costPerProof = getProvingCost(proof as ProofWithCluster)
-  const costPerMgas = costPerProof
-    ? costPerProof / (proof.block.gas_used / 1e6)
-    : null
+  const costPerMgas =
+    costPerProof && proof.block.gas_used
+      ? costPerProof / (proof.block.gas_used / 1e6)
+      : null
 
   // TODO:TEAM - mobile responsiveness
   return (
@@ -74,7 +75,7 @@ export const ClusterProofRow = ({ proof }: ClusterProofRowProps) => {
         </div>
         <div className="font-sans text-xs text-body-secondary">
           total to proof:{" "}
-          {proof.proved_timestamp ? (
+          {proof.proved_timestamp && proof.block.timestamp ? (
             prettyMs(
               differenceInMilliseconds(
                 new Date(proof.proved_timestamp),

--- a/components/ProofRow.tsx
+++ b/components/ProofRow.tsx
@@ -69,7 +69,7 @@ const ProofRow = ({ proof, block }: ProofRowProps) => {
   const isAvailable = isCompleted(proof) && hasProvedTimestamp(proof)
 
   const timeToProof =
-    isAvailable && proved_timestamp
+    isAvailable && proved_timestamp && block.timestamp
       ? Math.max(
           new Date(proved_timestamp).getTime() -
             new Date(block.timestamp).getTime(),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -67,10 +67,10 @@ export const blocks = pgTable(
     block_number: bigint("block_number", { mode: "number" })
       .primaryKey()
       .notNull(),
-    timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
-    gas_used: bigint("gas_used", { mode: "number" }).notNull(),
-    transaction_count: smallint("transaction_count").notNull(),
-    hash: text().notNull(),
+    timestamp: timestamp({ withTimezone: true, mode: "string" }),
+    gas_used: bigint("gas_used", { mode: "number" }),
+    transaction_count: smallint("transaction_count"),
+    hash: text(),
     created_at: timestamp("created_at", {
       withTimezone: true,
       mode: "string",

--- a/lib/proofs.ts
+++ b/lib/proofs.ts
@@ -279,7 +279,7 @@ export const getCostPerProofStats = (
 
 export const getCostPerMgasStats = (
   proofs: ProofWithCluster[] | undefined,
-  gasUsed: number | undefined
+  gasUsed?: number | null
 ): Stats | null => {
   if (!proofs || !proofs.length || !gasUsed) return null
 
@@ -335,9 +335,9 @@ export const getProvingTimeStats = (
 
 export const getTotalTTPStats = (
   proofs: ProofWithCluster[],
-  timestamp: string
+  timestamp?: string | null
 ): Stats | null => {
-  if (!proofs.length) return null
+  if (!proofs.length || !timestamp) return null
 
   const availableProofs = proofs
     .filter(isCompleted)

--- a/supabase/migrations/0026_update-blocks-table.sql
+++ b/supabase/migrations/0026_update-blocks-table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "blocks" ALTER COLUMN "timestamp" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "blocks" ALTER COLUMN "gas_used" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "blocks" ALTER COLUMN "transaction_count" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "blocks" ALTER COLUMN "hash" DROP NOT NULL;

--- a/supabase/migrations/meta/0025_snapshot.json
+++ b/supabase/migrations/meta/0025_snapshot.json
@@ -1,0 +1,2329 @@
+{
+  "id": "73a6be76-121f-4c73-8cac-4c5df58330b2",
+  "prevId": "06e718c5-53f2-4cc4-a0d5-73e7ec3977bd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_auth_tokens": {
+      "name": "api_auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "key_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_auth_tokens_team_id_teams_id_fk": {
+          "name": "api_auth_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_auth_tokens",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_auth_tokens_token_unique": {
+          "name": "api_auth_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Allow users to see API token entries they own": {
+          "name": "Allow users to see API token entries they own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "anon"
+          ],
+          "using": "is_allowed_apikey(((current_setting('request.headers'::text, true))::json ->> 'ethkey'::text), '{all,read}'::key_mode[])"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmarks": {
+      "name": "benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "benchmarks_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_count": {
+          "name": "transaction_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_instances": {
+      "name": "cloud_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cloud_instances_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_name": {
+          "name": "instance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_price": {
+          "name": "hourly_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_arch": {
+          "name": "cpu_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_effective_cores": {
+          "name": "cpu_effective_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_name": {
+          "name": "cpu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_arch": {
+          "name": "gpu_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_name": {
+          "name": "gpu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_memory": {
+          "name": "gpu_memory",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobo_name": {
+          "name": "mobo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_name": {
+          "name": "disk_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_space": {
+          "name": "disk_space",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cloud_instances_provider_id_cloud_providers_id_fk": {
+          "name": "cloud_instances_provider_id_cloud_providers_id_fk",
+          "tableFrom": "cloud_instances",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "tableTo": "cloud_providers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_instances_instance_name_unique": {
+          "name": "cloud_instances_instance_name_unique",
+          "columns": [
+            "instance_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_providers": {
+      "name": "cloud_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cloud_providers_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_providers_name_unique": {
+          "name": "cloud_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_benchmarks": {
+      "name": "cluster_benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cluster_benchmarks_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_id": {
+          "name": "benchmark_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cluster_benchmarks_cluster_id_clusters_id_fk": {
+          "name": "cluster_benchmarks_cluster_id_clusters_id_fk",
+          "tableFrom": "cluster_benchmarks",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_benchmarks_benchmark_id_benchmarks_id_fk": {
+          "name": "cluster_benchmarks_benchmark_id_benchmarks_id_fk",
+          "tableFrom": "cluster_benchmarks",
+          "columnsFrom": [
+            "benchmark_id"
+          ],
+          "tableTo": "benchmarks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_machines": {
+      "name": "cluster_machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cluster_machines_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cluster_version_id": {
+          "name": "cluster_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_count": {
+          "name": "machine_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_instance_id": {
+          "name": "cloud_instance_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_instance_count": {
+          "name": "cloud_instance_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cluster_machines_cluster_version_id_idx": {
+          "name": "cluster_machines_cluster_version_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cluster_machines_cloud_instance_id_idx": {
+          "name": "cluster_machines_cloud_instance_id_idx",
+          "columns": [
+            {
+              "expression": "cloud_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cluster_machines_cluster_version_id_cluster_versions_id_fk": {
+          "name": "cluster_machines_cluster_version_id_cluster_versions_id_fk",
+          "tableFrom": "cluster_machines",
+          "columnsFrom": [
+            "cluster_version_id"
+          ],
+          "tableTo": "cluster_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_machines_machine_id_machines_id_fk": {
+          "name": "cluster_machines_machine_id_machines_id_fk",
+          "tableFrom": "cluster_machines",
+          "columnsFrom": [
+            "machine_id"
+          ],
+          "tableTo": "machines",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_machines_cloud_instance_id_cloud_instances_id_fk": {
+          "name": "cluster_machines_cloud_instance_id_cloud_instances_id_fk",
+          "tableFrom": "cluster_machines",
+          "columnsFrom": [
+            "cloud_instance_id"
+          ],
+          "tableTo": "cloud_instances",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_versions": {
+      "name": "cluster_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "cluster_versions_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zkvm_version_id": {
+          "name": "zkvm_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cluster_versions_cluster_id_idx": {
+          "name": "cluster_versions_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cluster_versions_cluster_id_clusters_id_fk": {
+          "name": "cluster_versions_cluster_id_clusters_id_fk",
+          "tableFrom": "cluster_versions",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "tableTo": "clusters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "cluster_versions_zkvm_version_id_zkvm_versions_id_fk": {
+          "name": "cluster_versions_zkvm_version_id_zkvm_versions_id_fk",
+          "tableFrom": "cluster_versions",
+          "columnsFrom": [
+            "zkvm_version_id"
+          ],
+          "tableTo": "zkvm_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardware": {
+          "name": "hardware",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_type": {
+          "name": "cycle_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_source": {
+          "name": "is_open_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_multi_machine": {
+          "name": "is_multi_machine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "software_link": {
+          "name": "software_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clusters_team_id_teams_id_fk": {
+          "name": "clusters_team_id_teams_id_fk",
+          "tableFrom": "clusters",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "machines_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "cpu_model": {
+          "name": "cpu_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_memory_gb": {
+          "name": "gpu_memory_gb",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_size_gb": {
+          "name": "memory_size_gb",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_count": {
+          "name": "memory_count",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_size_gb": {
+          "name": "storage_size_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tera_flops": {
+          "name": "total_tera_flops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_between_machines": {
+          "name": "network_between_machines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "programs_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "verifier_id": {
+          "name": "verifier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_verifier_id_unique": {
+          "name": "programs_verifier_id_unique",
+          "columns": [
+            "verifier_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proofs": {
+      "name": "proofs",
+      "schema": "",
+      "columns": {
+        "proof_id": {
+          "name": "proof_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "proofs_proof_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proving_cycles": {
+          "name": "proving_cycles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "proved_timestamp": {
+          "name": "proved_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proving_timestamp": {
+          "name": "proving_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_timestamp": {
+          "name": "queued_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_version_id": {
+          "name": "cluster_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proving_time": {
+          "name": "proving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proofs_cluster_version_id_idx": {
+          "name": "proofs_cluster_version_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proofs_proved_timestamp_idx": {
+          "name": "proofs_proved_timestamp_idx",
+          "columns": [
+            {
+              "expression": "proved_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proofs_created_at_idx": {
+          "name": "proofs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proofs_block_number_blocks_block_number_fk": {
+          "name": "proofs_block_number_blocks_block_number_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "block_number"
+          ],
+          "tableTo": "blocks",
+          "columnsTo": [
+            "block_number"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "proofs_team_id_teams_id_fk": {
+          "name": "proofs_team_id_teams_id_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "proofs_cluster_version_id_cluster_versions_id_fk": {
+          "name": "proofs_cluster_version_id_cluster_versions_id_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "cluster_version_id"
+          ],
+          "tableTo": "cluster_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "proofs_program_id_programs_id_fk": {
+          "name": "proofs_program_id_programs_id_fk",
+          "tableFrom": "proofs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "tableTo": "programs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_block_cluster_version": {
+          "name": "unique_block_cluster_version",
+          "columns": [
+            "block_number",
+            "cluster_version_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable updates for users with an api key": {
+          "name": "Enable updates for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "is_allowed_apikey(((current_setting('request.headers'::text, true))::json ->> 'ethkey'::text), '{all,write}'::key_mode[])"
+        },
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ]
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {
+        "proofs_proof_status_check": {
+          "name": "proofs_proof_status_check",
+          "value": "proof_status = ANY (ARRAY['queued'::text, 'proving'::text, 'proved'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.proofs_daily_stats": {
+      "name": "proofs_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "proofs_daily_stats_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost": {
+          "name": "avg_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_cost": {
+          "name": "median_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_latency": {
+          "name": "avg_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_latency": {
+          "name": "median_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "proofs_daily_stats_date_key": {
+          "name": "proofs_daily_stats_date_key",
+          "columns": [
+            "date"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prover_daily_stats": {
+      "name": "prover_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "prover_daily_stats_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost": {
+          "name": "avg_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_cost": {
+          "name": "median_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_latency": {
+          "name": "avg_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_latency": {
+          "name": "median_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prover_daily_stats_team_id_teams_id_fk": {
+          "name": "prover_daily_stats_team_id_teams_id_fk",
+          "tableFrom": "prover_daily_stats",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prover_daily_stats_date_team_key": {
+          "name": "prover_daily_stats_date_team_key",
+          "columns": [
+            "date",
+            "team_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recursive_root_proofs": {
+      "name": "recursive_root_proofs",
+      "schema": "",
+      "columns": {
+        "root_proof_id": {
+          "name": "root_proof_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "recursive_root_proofs_root_proof_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_proof": {
+          "name": "root_proof",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_proof_size": {
+          "name": "root_proof_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proof_size": {
+          "name": "total_proof_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recursive_root_proofs_block_number_blocks_block_number_fk": {
+          "name": "recursive_root_proofs_block_number_blocks_block_number_fk",
+          "tableFrom": "recursive_root_proofs",
+          "columnsFrom": [
+            "block_number"
+          ],
+          "tableTo": "blocks",
+          "columnsTo": [
+            "block_number"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "recursive_root_proofs_team_id_teams_id_fk": {
+          "name": "recursive_root_proofs_team_id_teams_id_fk",
+          "tableFrom": "recursive_root_proofs",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_quota_bytes": {
+          "name": "storage_quota_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_id_users_id_fk": {
+          "name": "teams_id_users_id_fk",
+          "tableFrom": "teams",
+          "columnsFrom": [
+            "id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_performance_metrics": {
+      "name": "zkvm_performance_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvm_performance_metrics_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_ms": {
+          "name": "verification_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_performance_metrics_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_performance_metrics_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_performance_metrics",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "tableTo": "zkvms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvm_performance_metrics_zkvm_id_unique": {
+          "name": "zkvm_performance_metrics_zkvm_id_unique",
+          "columns": [
+            "zkvm_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_security_metrics": {
+      "name": "zkvm_security_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvm_security_metrics_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_soundness": {
+          "name": "protocol_soundness",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "implementation_soundness": {
+          "name": "implementation_soundness",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evm_stf_bytecode": {
+          "name": "evm_stf_bytecode",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantum_security": {
+          "name": "quantum_security",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_target_bits": {
+          "name": "security_target_bits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_bounty_amount": {
+          "name": "max_bounty_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_setup": {
+          "name": "trusted_setup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_security_metrics_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_security_metrics_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_security_metrics",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "tableTo": "zkvms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvm_security_metrics_zkvm_id_unique": {
+          "name": "zkvm_security_metrics_zkvm_id_unique",
+          "columns": [
+            "zkvm_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_versions": {
+      "name": "zkvm_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvm_versions_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_versions_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_versions_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_versions",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "tableTo": "zkvms",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvms": {
+      "name": "zkvms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "zkvms_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "byDefault"
+          }
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isa": {
+          "name": "isa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continuations": {
+          "name": "continuations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dual_licenses": {
+          "name": "dual_licenses",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_open_source": {
+          "name": "is_open_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_proving_mainnet": {
+          "name": "is_proving_mainnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parallelizable_proving": {
+          "name": "parallelizable_proving",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "precompiles": {
+          "name": "precompiles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frontend": {
+          "name": "frontend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvms_team_id_teams_id_fk": {
+          "name": "zkvms_team_id_teams_id_fk",
+          "tableFrom": "zkvms",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvms_slug_unique": {
+          "name": "zkvms_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.key_mode": {
+      "name": "key_mode",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "all",
+        "upload"
+      ]
+    },
+    "public.severity_level": {
+      "name": "severity_level",
+      "schema": "public",
+      "values": [
+        "red",
+        "yellow",
+        "green"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "public.cluster_summary": {
+      "name": "cluster_summary",
+      "schema": "public",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_nickname": {
+          "name": "cluster_nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT c.id as cluster_id,\n      c.nickname as cluster_nickname,\n      c.team_id,\n      COALESCE(sum(cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) / NULLIF(count(p.proof_id), 0)::double precision, 0::double precision) AS avg_cost_per_proof,\n      avg(p.proving_time) AS avg_proving_time\n    FROM clusters c\n    LEFT JOIN cluster_versions cv ON c.id = cv.cluster_id\n    LEFT JOIN proofs p ON cv.id = p.cluster_version_id AND p.proof_status = 'proved'::text\n    LEFT JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    LEFT JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    GROUP BY c.id",
+      "materialized": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "isExisting": false
+    },
+    "public.recent_summary": {
+      "name": "recent_summary",
+      "schema": "public",
+      "columns": {
+        "total_proven_blocks": {
+          "name": "total_proven_blocks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_cost_per_proof": {
+          "name": "median_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_proving_time": {
+          "name": "median_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT count(DISTINCT b.block_number) AS total_proven_blocks,\n      -- Calculate average cost per proof\n      COALESCE(avg(cm.cloud_instance_count::double precision * ci.hourly_price * p.proving_time::double precision / (1000.0 * 60::numeric * 60::numeric)::double precision), 0::numeric::double precision) AS avg_cost_per_proof,\n      -- Calculate median cost per proof\n      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY cm.cloud_instance_count::double precision * ci.hourly_price * p.proving_time::double precision / (1000.0 * 60::numeric * 60::numeric)::double precision), 0::numeric::double precision) AS median_cost_per_proof,\n      -- Calculate average latency\n      COALESCE(avg(p.proving_time), 0::numeric) AS avg_proving_time,\n      -- Calculate median latency\n      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY p.proving_time), 0::numeric) AS median_proving_time\n    FROM blocks b\n    INNER JOIN proofs p ON b.block_number = p.block_number AND p.proof_status = 'proved'::text\n    INNER JOIN cluster_versions cv ON p.cluster_version_id = cv.id\n    INNER JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    INNER JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    WHERE b.\"timestamp\" >= (now() - '30 days'::interval)",
+      "materialized": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "isExisting": false
+    },
+    "public.teams_summary": {
+      "name": "teams_summary",
+      "schema": "public",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof_multi": {
+          "name": "avg_cost_per_proof_multi",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time_multi": {
+          "name": "avg_proving_time_multi",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs_multi": {
+          "name": "total_proofs_multi",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof_single": {
+          "name": "avg_cost_per_proof_single",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time_single": {
+          "name": "avg_proving_time_single",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs_single": {
+          "name": "total_proofs_single",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT t.id as team_id,\n      t.name as team_name,\n      t.logo_url,\n      -- All proofs\n      COALESCE(sum(cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) / NULLIF(count(p.proof_id), 0)::double precision, 0::double precision) AS avg_cost_per_proof,\n      COALESCE(avg(p.proving_time), 0::numeric) AS avg_proving_time,\n      count(p.proof_id) AS total_proofs,\n      -- Multi-machine proofs\n      COALESCE(sum(CASE WHEN c.is_multi_machine THEN (cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) ELSE 0 END) / NULLIF(sum(CASE WHEN c.is_multi_machine THEN 1 ELSE 0 END), 0)::double precision, 0::double precision) AS avg_cost_per_proof_multi,\n      COALESCE(avg(CASE WHEN c.is_multi_machine THEN p.proving_time ELSE NULL END), 0::numeric) AS avg_proving_time_multi,\n      sum(CASE WHEN c.is_multi_machine THEN 1 ELSE 0 END) AS total_proofs_multi,\n      -- Single-machine proofs\n      COALESCE(sum(CASE WHEN NOT c.is_multi_machine THEN (cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) ELSE 0 END) / NULLIF(sum(CASE WHEN NOT c.is_multi_machine THEN 1 ELSE 0 END), 0)::double precision, 0::double precision) AS avg_cost_per_proof_single,\n      COALESCE(avg(CASE WHEN NOT c.is_multi_machine THEN p.proving_time ELSE NULL END), 0::numeric) AS avg_proving_time_single,\n      sum(CASE WHEN NOT c.is_multi_machine THEN 1 ELSE 0 END) AS total_proofs_single\n    FROM teams t\n    LEFT JOIN proofs p ON t.id = p.team_id AND p.proof_status = 'proved'::text\n    LEFT JOIN cluster_versions cv ON p.cluster_version_id = cv.id\n    LEFT JOIN clusters c ON cv.cluster_id = c.id\n    LEFT JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    LEFT JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    GROUP BY t.id",
+      "materialized": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "isExisting": false
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/0026_snapshot.json
+++ b/supabase/migrations/meta/0026_snapshot.json
@@ -1,0 +1,2329 @@
+{
+  "id": "2f746d33-490e-4bd6-bf78-3ad74e65e51c",
+  "prevId": "73a6be76-121f-4c73-8cac-4c5df58330b2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_auth_tokens": {
+      "name": "api_auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "key_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_auth_tokens_team_id_teams_id_fk": {
+          "name": "api_auth_tokens_team_id_teams_id_fk",
+          "tableFrom": "api_auth_tokens",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_auth_tokens_token_unique": {
+          "name": "api_auth_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {
+        "Allow users to see API token entries they own": {
+          "name": "Allow users to see API token entries they own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "anon"
+          ],
+          "using": "is_allowed_apikey(((current_setting('request.headers'::text, true))::json ->> 'ethkey'::text), '{all,read}'::key_mode[])"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmarks": {
+      "name": "benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "benchmarks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_count": {
+          "name": "transaction_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_instances": {
+      "name": "cloud_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cloud_instances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_name": {
+          "name": "instance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_price": {
+          "name": "hourly_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_arch": {
+          "name": "cpu_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_effective_cores": {
+          "name": "cpu_effective_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_name": {
+          "name": "cpu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_arch": {
+          "name": "gpu_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_name": {
+          "name": "gpu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_memory": {
+          "name": "gpu_memory",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobo_name": {
+          "name": "mobo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_name": {
+          "name": "disk_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_space": {
+          "name": "disk_space",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cloud_instances_provider_id_cloud_providers_id_fk": {
+          "name": "cloud_instances_provider_id_cloud_providers_id_fk",
+          "tableFrom": "cloud_instances",
+          "tableTo": "cloud_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_instances_instance_name_unique": {
+          "name": "cloud_instances_instance_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_name"
+          ]
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_providers": {
+      "name": "cloud_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cloud_providers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cloud_providers_name_unique": {
+          "name": "cloud_providers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_benchmarks": {
+      "name": "cluster_benchmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cluster_benchmarks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_id": {
+          "name": "benchmark_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cluster_benchmarks_cluster_id_clusters_id_fk": {
+          "name": "cluster_benchmarks_cluster_id_clusters_id_fk",
+          "tableFrom": "cluster_benchmarks",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "cluster_benchmarks_benchmark_id_benchmarks_id_fk": {
+          "name": "cluster_benchmarks_benchmark_id_benchmarks_id_fk",
+          "tableFrom": "cluster_benchmarks",
+          "tableTo": "benchmarks",
+          "columnsFrom": [
+            "benchmark_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_machines": {
+      "name": "cluster_machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cluster_machines_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "cluster_version_id": {
+          "name": "cluster_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_count": {
+          "name": "machine_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_instance_id": {
+          "name": "cloud_instance_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_instance_count": {
+          "name": "cloud_instance_count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cluster_machines_cluster_version_id_idx": {
+          "name": "cluster_machines_cluster_version_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cluster_machines_cloud_instance_id_idx": {
+          "name": "cluster_machines_cloud_instance_id_idx",
+          "columns": [
+            {
+              "expression": "cloud_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cluster_machines_cluster_version_id_cluster_versions_id_fk": {
+          "name": "cluster_machines_cluster_version_id_cluster_versions_id_fk",
+          "tableFrom": "cluster_machines",
+          "tableTo": "cluster_versions",
+          "columnsFrom": [
+            "cluster_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "cluster_machines_machine_id_machines_id_fk": {
+          "name": "cluster_machines_machine_id_machines_id_fk",
+          "tableFrom": "cluster_machines",
+          "tableTo": "machines",
+          "columnsFrom": [
+            "machine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "cluster_machines_cloud_instance_id_cloud_instances_id_fk": {
+          "name": "cluster_machines_cloud_instance_id_cloud_instances_id_fk",
+          "tableFrom": "cluster_machines",
+          "tableTo": "cloud_instances",
+          "columnsFrom": [
+            "cloud_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_versions": {
+      "name": "cluster_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cluster_versions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zkvm_version_id": {
+          "name": "zkvm_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cluster_versions_cluster_id_idx": {
+          "name": "cluster_versions_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cluster_versions_cluster_id_clusters_id_fk": {
+          "name": "cluster_versions_cluster_id_clusters_id_fk",
+          "tableFrom": "cluster_versions",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "cluster_versions_zkvm_version_id_zkvm_versions_id_fk": {
+          "name": "cluster_versions_zkvm_version_id_zkvm_versions_id_fk",
+          "tableFrom": "cluster_versions",
+          "tableTo": "zkvm_versions",
+          "columnsFrom": [
+            "zkvm_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardware": {
+          "name": "hardware",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_type": {
+          "name": "cycle_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open_source": {
+          "name": "is_open_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_multi_machine": {
+          "name": "is_multi_machine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "software_link": {
+          "name": "software_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clusters_team_id_teams_id_fk": {
+          "name": "clusters_team_id_teams_id_fk",
+          "tableFrom": "clusters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "machines_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "cpu_model": {
+          "name": "cpu_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_memory_gb": {
+          "name": "gpu_memory_gb",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_size_gb": {
+          "name": "memory_size_gb",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_count": {
+          "name": "memory_count",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_size_gb": {
+          "name": "storage_size_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tera_flops": {
+          "name": "total_tera_flops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_between_machines": {
+          "name": "network_between_machines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "programs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "verifier_id": {
+          "name": "verifier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_verifier_id_unique": {
+          "name": "programs_verifier_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "verifier_id"
+          ]
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proofs": {
+      "name": "proofs",
+      "schema": "",
+      "columns": {
+        "proof_id": {
+          "name": "proof_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "proofs_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_status": {
+          "name": "proof_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proving_cycles": {
+          "name": "proving_cycles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "proved_timestamp": {
+          "name": "proved_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proving_timestamp": {
+          "name": "proving_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_timestamp": {
+          "name": "queued_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_version_id": {
+          "name": "cluster_version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proving_time": {
+          "name": "proving_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proofs_cluster_version_id_idx": {
+          "name": "proofs_cluster_version_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proofs_proved_timestamp_idx": {
+          "name": "proofs_proved_timestamp_idx",
+          "columns": [
+            {
+              "expression": "proved_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proofs_created_at_idx": {
+          "name": "proofs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proofs_block_number_blocks_block_number_fk": {
+          "name": "proofs_block_number_blocks_block_number_fk",
+          "tableFrom": "proofs",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_number"
+          ],
+          "columnsTo": [
+            "block_number"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proofs_team_id_teams_id_fk": {
+          "name": "proofs_team_id_teams_id_fk",
+          "tableFrom": "proofs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "proofs_cluster_version_id_cluster_versions_id_fk": {
+          "name": "proofs_cluster_version_id_cluster_versions_id_fk",
+          "tableFrom": "proofs",
+          "tableTo": "cluster_versions",
+          "columnsFrom": [
+            "cluster_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "proofs_program_id_programs_id_fk": {
+          "name": "proofs_program_id_programs_id_fk",
+          "tableFrom": "proofs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_block_cluster_version": {
+          "name": "unique_block_cluster_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "cluster_version_id"
+          ]
+        }
+      },
+      "policies": {
+        "Enable updates for users with an api key": {
+          "name": "Enable updates for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "is_allowed_apikey(((current_setting('request.headers'::text, true))::json ->> 'ethkey'::text), '{all,write}'::key_mode[])"
+        },
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ]
+        },
+        "Enable insert for users with an api key": {
+          "name": "Enable insert for users with an api key",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {
+        "proofs_proof_status_check": {
+          "name": "proofs_proof_status_check",
+          "value": "proof_status = ANY (ARRAY['queued'::text, 'proving'::text, 'proved'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.proofs_daily_stats": {
+      "name": "proofs_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "proofs_daily_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost": {
+          "name": "avg_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_cost": {
+          "name": "median_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_latency": {
+          "name": "avg_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_latency": {
+          "name": "median_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "proofs_daily_stats_date_key": {
+          "name": "proofs_daily_stats_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prover_daily_stats": {
+      "name": "prover_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "prover_daily_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_cost": {
+          "name": "avg_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_cost": {
+          "name": "median_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_latency": {
+          "name": "avg_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_latency": {
+          "name": "median_latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prover_daily_stats_team_id_teams_id_fk": {
+          "name": "prover_daily_stats_team_id_teams_id_fk",
+          "tableFrom": "prover_daily_stats",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prover_daily_stats_date_team_key": {
+          "name": "prover_daily_stats_date_team_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recursive_root_proofs": {
+      "name": "recursive_root_proofs",
+      "schema": "",
+      "columns": {
+        "root_proof_id": {
+          "name": "root_proof_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "recursive_root_proofs_root_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_proof": {
+          "name": "root_proof",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_proof_size": {
+          "name": "root_proof_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_proof_size": {
+          "name": "total_proof_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recursive_root_proofs_block_number_blocks_block_number_fk": {
+          "name": "recursive_root_proofs_block_number_blocks_block_number_fk",
+          "tableFrom": "recursive_root_proofs",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_number"
+          ],
+          "columnsTo": [
+            "block_number"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "recursive_root_proofs_team_id_teams_id_fk": {
+          "name": "recursive_root_proofs_team_id_teams_id_fk",
+          "tableFrom": "recursive_root_proofs",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_org": {
+          "name": "github_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_quota_bytes": {
+          "name": "storage_quota_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_id_users_id_fk": {
+          "name": "teams_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_performance_metrics": {
+      "name": "zkvm_performance_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "zkvm_performance_metrics_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_ms": {
+          "name": "verification_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_performance_metrics_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_performance_metrics_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_performance_metrics",
+          "tableTo": "zkvms",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvm_performance_metrics_zkvm_id_unique": {
+          "name": "zkvm_performance_metrics_zkvm_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "zkvm_id"
+          ]
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_security_metrics": {
+      "name": "zkvm_security_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "zkvm_security_metrics_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_soundness": {
+          "name": "protocol_soundness",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "implementation_soundness": {
+          "name": "implementation_soundness",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evm_stf_bytecode": {
+          "name": "evm_stf_bytecode",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantum_security": {
+          "name": "quantum_security",
+          "type": "severity_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_target_bits": {
+          "name": "security_target_bits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_bounty_amount": {
+          "name": "max_bounty_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trusted_setup": {
+          "name": "trusted_setup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_security_metrics_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_security_metrics_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_security_metrics",
+          "tableTo": "zkvms",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvm_security_metrics_zkvm_id_unique": {
+          "name": "zkvm_security_metrics_zkvm_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "zkvm_id"
+          ]
+        }
+      },
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvm_versions": {
+      "name": "zkvm_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "zkvm_versions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "zkvm_id": {
+          "name": "zkvm_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvm_versions_zkvm_id_zkvms_id_fk": {
+          "name": "zkvm_versions_zkvm_id_zkvms_id_fk",
+          "tableFrom": "zkvm_versions",
+          "tableTo": "zkvms",
+          "columnsFrom": [
+            "zkvm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zkvms": {
+      "name": "zkvms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "zkvms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isa": {
+          "name": "isa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continuations": {
+          "name": "continuations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dual_licenses": {
+          "name": "dual_licenses",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_open_source": {
+          "name": "is_open_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_proving_mainnet": {
+          "name": "is_proving_mainnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parallelizable_proving": {
+          "name": "parallelizable_proving",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "precompiles": {
+          "name": "precompiles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frontend": {
+          "name": "frontend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zkvms_team_id_teams_id_fk": {
+          "name": "zkvms_team_id_teams_id_fk",
+          "tableFrom": "zkvms",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zkvms_slug_unique": {
+          "name": "zkvms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.key_mode": {
+      "name": "key_mode",
+      "schema": "public",
+      "values": [
+        "read",
+        "write",
+        "all",
+        "upload"
+      ]
+    },
+    "public.severity_level": {
+      "name": "severity_level",
+      "schema": "public",
+      "values": [
+        "red",
+        "yellow",
+        "green"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.cluster_summary": {
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_nickname": {
+          "name": "cluster_nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT c.id as cluster_id,\n      c.nickname as cluster_nickname,\n      c.team_id,\n      COALESCE(sum(cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) / NULLIF(count(p.proof_id), 0)::double precision, 0::double precision) AS avg_cost_per_proof,\n      avg(p.proving_time) AS avg_proving_time\n    FROM clusters c\n    LEFT JOIN cluster_versions cv ON c.id = cv.cluster_id\n    LEFT JOIN proofs p ON cv.id = p.cluster_version_id AND p.proof_status = 'proved'::text\n    LEFT JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    LEFT JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    GROUP BY c.id",
+      "name": "cluster_summary",
+      "schema": "public",
+      "isExisting": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "materialized": false
+    },
+    "public.recent_summary": {
+      "columns": {
+        "total_proven_blocks": {
+          "name": "total_proven_blocks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_cost_per_proof": {
+          "name": "median_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_proving_time": {
+          "name": "median_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT count(DISTINCT b.block_number) AS total_proven_blocks,\n      -- Calculate average cost per proof\n      COALESCE(avg(cm.cloud_instance_count::double precision * ci.hourly_price * p.proving_time::double precision / (1000.0 * 60::numeric * 60::numeric)::double precision), 0::numeric::double precision) AS avg_cost_per_proof,\n      -- Calculate median cost per proof\n      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY cm.cloud_instance_count::double precision * ci.hourly_price * p.proving_time::double precision / (1000.0 * 60::numeric * 60::numeric)::double precision), 0::numeric::double precision) AS median_cost_per_proof,\n      -- Calculate average latency\n      COALESCE(avg(p.proving_time), 0::numeric) AS avg_proving_time,\n      -- Calculate median latency\n      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY p.proving_time), 0::numeric) AS median_proving_time\n    FROM blocks b\n    INNER JOIN proofs p ON b.block_number = p.block_number AND p.proof_status = 'proved'::text\n    INNER JOIN cluster_versions cv ON p.cluster_version_id = cv.id\n    INNER JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    INNER JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    WHERE b.\"timestamp\" >= (now() - '30 days'::interval)",
+      "name": "recent_summary",
+      "schema": "public",
+      "isExisting": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "materialized": false
+    },
+    "public.teams_summary": {
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof": {
+          "name": "avg_cost_per_proof",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time": {
+          "name": "avg_proving_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs": {
+          "name": "total_proofs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof_multi": {
+          "name": "avg_cost_per_proof_multi",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time_multi": {
+          "name": "avg_proving_time_multi",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs_multi": {
+          "name": "total_proofs_multi",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_cost_per_proof_single": {
+          "name": "avg_cost_per_proof_single",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_proving_time_single": {
+          "name": "avg_proving_time_single",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_proofs_single": {
+          "name": "total_proofs_single",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    SELECT t.id as team_id,\n      t.name as team_name,\n      t.logo_url,\n      -- All proofs\n      COALESCE(sum(cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) / NULLIF(count(p.proof_id), 0)::double precision, 0::double precision) AS avg_cost_per_proof,\n      COALESCE(avg(p.proving_time), 0::numeric) AS avg_proving_time,\n      count(p.proof_id) AS total_proofs,\n      -- Multi-machine proofs\n      COALESCE(sum(CASE WHEN c.is_multi_machine THEN (cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) ELSE 0 END) / NULLIF(sum(CASE WHEN c.is_multi_machine THEN 1 ELSE 0 END), 0)::double precision, 0::double precision) AS avg_cost_per_proof_multi,\n      COALESCE(avg(CASE WHEN c.is_multi_machine THEN p.proving_time ELSE NULL END), 0::numeric) AS avg_proving_time_multi,\n      sum(CASE WHEN c.is_multi_machine THEN 1 ELSE 0 END) AS total_proofs_multi,\n      -- Single-machine proofs\n      COALESCE(sum(CASE WHEN NOT c.is_multi_machine THEN (cm.cloud_instance_count::double precision * ci.hourly_price * (p.proving_time::numeric / (1000.0 * 60::numeric * 60::numeric))::double precision) ELSE 0 END) / NULLIF(sum(CASE WHEN NOT c.is_multi_machine THEN 1 ELSE 0 END), 0)::double precision, 0::double precision) AS avg_cost_per_proof_single,\n      COALESCE(avg(CASE WHEN NOT c.is_multi_machine THEN p.proving_time ELSE NULL END), 0::numeric) AS avg_proving_time_single,\n      sum(CASE WHEN NOT c.is_multi_machine THEN 1 ELSE 0 END) AS total_proofs_single\n    FROM teams t\n    LEFT JOIN proofs p ON t.id = p.team_id AND p.proof_status = 'proved'::text\n    LEFT JOIN cluster_versions cv ON p.cluster_version_id = cv.id\n    LEFT JOIN clusters c ON cv.cluster_id = c.id\n    LEFT JOIN cluster_machines cm ON cv.id = cm.cluster_version_id\n    LEFT JOIN cloud_instances ci ON cm.cloud_instance_id = ci.id\n    GROUP BY t.id",
+      "name": "teams_summary",
+      "schema": "public",
+      "isExisting": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -176,6 +176,20 @@
       "when": 1754503525807,
       "tag": "0024_proof-monitoring-cron",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1759678664227,
+      "tag": "0025_separate-alert-scheduling",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1759678776046,
+      "tag": "0026_update-blocks-table",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
This PR changes our proof post requests so that when a proof is queued we don't fetch the block data. When a proof is queued, we now just create the block using the block number and placeholder data. At this point, we don't really need the block data and at times we return 500s to provers when the block data isn't ready yet from our RPC.

We now update the block data when the proof moves into the 'proved' stage when the block data should be available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Block persistence now uses a dedicated update flow to fetch and upsert upstream block data, improving record freshness.

* Bug Fixes / UX
  * UI hides or disables block fields/actions when data is missing (timestamp, hash, gas, counts).
  * Metrics and duration calculations now safely skip or return empty when required data is absent.

* Database Migration
  * Blocks table columns (timestamp, gas_used, transaction_count, hash) made nullable.

* Chores
  * Added migration snapshots and journal entries supporting the schema update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->