### PR TITLE
refactor: download block proofs api

### DIFF
--- a/app/api/v0/proofs/download/[id]/route.ts
+++ b/app/api/v0/proofs/download/[id]/route.ts
@@ -37,7 +37,7 @@ export async function GET(
   const teamName = team?.name
     ? team.name
     : proofRow.cluster_version.cluster.id.split("-")[0]
-  const filename = `${proofRow.block_number}_${teamName}_${id}.txt`
+  const filename = `${proofRow.block_number}_${teamName}_${id}.bin`
 
   const blob = await downloadProofBinary(filename)
 

--- a/app/api/v0/proofs/download/block/[block]/route.ts
+++ b/app/api/v0/proofs/download/block/[block]/route.ts
@@ -8,7 +8,7 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ block: string }> }
 ) {
-  const { block } = await params
+  const { block: blockNumber } = await params
 
   const proofRows = await db.query.proofs.findMany({
     columns: {
@@ -31,7 +31,7 @@ export async function GET(
     },
     where: (proofs, { eq, and }) =>
       and(
-        eq(proofs.block_number, Number(block)),
+        eq(proofs.block_number, Number(blockNumber)),
         eq(proofs.proof_status, "proved")
       ),
   })
@@ -51,14 +51,14 @@ export async function GET(
       cycle_type,
     } = proofRow.cluster_version.cluster
     const teamName = team?.name ? team.name : cluster_id.split("-")[0]
-    const filenameInStorage = `${proofRow.block_number}_${teamName}_${proofRow.proof_id}.txt`
+    const filenameInStorage = `${proofRow.block_number}_${teamName}_${proofRow.proof_id}.bin`
 
     const blob = await downloadProofBinary(filenameInStorage)
     if (blob) {
       const arrayBuffer = await blob.arrayBuffer()
       const binaryBuffer = Buffer.from(arrayBuffer)
 
-      const filename = `block_${block}_${proof_type}_${cycle_type}_${teamName}.txt`
+      const filename = `block_${blockNumber}_${proof_type}_${cycle_type}_${teamName}.bin`
       binaryBuffers.push({ binaryBuffer, filename })
     }
   }
@@ -74,7 +74,7 @@ export async function GET(
   return new Response(new Uint8Array(zipBuffer), {
     headers: {
       "Content-Type": "application/zip",
-      "Content-Disposition": `attachment; filename="block_${block}_all_proofs.zip"`,
+      "Content-Disposition": `attachment; filename="block_${blockNumber}_proofs.zip"`,
     },
   })
 }

--- a/app/api/v0/proofs/proved/route.ts
+++ b/app/api/v0/proofs/proved/route.ts
@@ -185,7 +185,7 @@ export const POST = withAuth(async ({ request, user, timestamp }) => {
       if (!storageQuotaExceeded) {
         const team = await getTeam(teamId)
         const teamName = team?.name ? team.name : cluster.id.split("-")[0]
-        const filename = `${block_number}_${teamName}_${newProof.proof_id}.txt`
+        const filename = `${block_number}_${teamName}_${newProof.proof_id}.bin`
         await uploadProofBinary(filename, binaryBuffer)
       }
 

--- a/components/proof-buttons/useDownloadAllProofs.tsx
+++ b/components/proof-buttons/useDownloadAllProofs.tsx
@@ -3,7 +3,9 @@ import { useCallback } from "react"
 export function useDownloadAllProofs() {
   const downloadAllProofs = useCallback(async (blockNumber: string) => {
     try {
-      const response = await fetch(`/api/v0/proofs/download/all/${blockNumber}`)
+      const response = await fetch(
+        `/api/v0/proofs/download/block/${blockNumber}`
+      )
       if (!response.ok) {
         throw new Error(
           `Failed to download proofs: ${response.status} ${response.statusText}`

--- a/lib/api/csp-benchmarks.ts
+++ b/lib/api/csp-benchmarks.ts
@@ -2,10 +2,7 @@ import { CSP_BENCHMARKS_BUCKET } from "../constants"
 
 import { createClient } from "@/utils/supabase/server"
 
-export const uploadCspBenchmarks = async (
-  filename: string,
-  buffer: Buffer
-) => {
+export const uploadCspBenchmarks = async (filename: string, buffer: Buffer) => {
   const supabase = await createClient()
 
   const { data, error } = await supabase.storage

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1753,7 +1753,7 @@
     "/verification-keys/upload": {
       "post": {
         "tags": [
-          "Verification Keys"
+          "Verification keys"
         ],
         "summary": "Upload verification key",
         "description": "Upload a verification key binary file to storage.",
@@ -1833,7 +1833,7 @@
     "/csp-benchmarks/upload": {
       "post": {
         "tags": [
-          "CSP Benchmarks"
+          "CSP benchmarks"
         ],
         "summary": "Upload CSP benchmarks",
         "description": "Upload a CSP benchmarks JSON file to storage.",
@@ -1903,6 +1903,56 @@
           },
           "403": {
             "description": "Forbidden: admin mode required"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/proofs/download/block/{block}": {
+      "get": {
+        "tags": [
+          "Proofs"
+        ],
+        "summary": "Download proofs by block number",
+        "description": "Download all proofs for a specific block number as a ZIP file containing proof binaries.",
+        "parameters": [
+          {
+            "name": "block",
+            "in": "path",
+            "description": "The block number to download proofs for",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 12345
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP file containing all proofs for the block",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Disposition": {
+                "description": "Attachment filename",
+                "schema": {
+                  "type": "string",
+                  "example": "attachment; filename=\"block_12345_proofs.zip\""
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No proofs found for this block number"
           },
           "500": {
             "description": "Internal server error"


### PR DESCRIPTION
Cleaning up this api for the demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoint for downloading proofs by block number as a consolidated ZIP file.

* **Chores**
  * Updated proof file download extension format.
  * Normalized API documentation tag naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->