### PR TITLE
fix: proof binaries bucket

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -39,7 +39,7 @@ export const DEFAULT_PAGE_STATE = {
 export const isNetlifyProduction = process.env.CONTEXT === "production"
 
 // Supabase storage buckets
-export const PROOF_BINARY_BUCKET = "proof_binaries"
+export const PROOF_BINARY_BUCKET = "proof-binaries"
 export const PUBLIC_ASSETS_BUCKET = "public-assets"
 export const VERIFICATION_KEYS_BUCKET = "verification-keys"
 export const CSP_BENCHMARKS_BUCKET = "csp-benchmarks"

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -17,10 +17,10 @@ export type Database = {
     Functions: {
       graphql: {
         Args: {
+          extensions?: Json
           operationName?: string
           query?: string
           variables?: Json
-          extensions?: Json
         }
         Returns: Json
       }
@@ -73,36 +73,24 @@ export type Database = {
           },
         ]
       }
-      aws_instance_pricing: {
+      benchmarks: {
         Row: {
           created_at: string
-          hourly_price: number
+          display_name: string
           id: number
-          instance_memory: number
-          instance_storage: string
-          instance_type: string
-          region: string
-          vcpu: number
+          operation_type: string
         }
         Insert: {
           created_at?: string
-          hourly_price: number
+          display_name: string
           id?: number
-          instance_memory: number
-          instance_storage: string
-          instance_type: string
-          region: string
-          vcpu: number
+          operation_type: string
         }
         Update: {
           created_at?: string
-          hourly_price?: number
+          display_name?: string
           id?: number
-          instance_memory?: number
-          instance_storage?: string
-          instance_type?: string
-          region?: string
-          vcpu?: number
+          operation_type?: string
         }
         Relationships: []
       }
@@ -110,61 +98,267 @@ export type Database = {
         Row: {
           block_number: number
           created_at: string
-          gas_used: number
-          hash: string
-          timestamp: string
-          transaction_count: number
+          gas_used: number | null
+          hash: string | null
+          timestamp: string | null
+          transaction_count: number | null
         }
         Insert: {
           block_number: number
           created_at?: string
-          gas_used: number
-          hash: string
-          timestamp: string
-          transaction_count: number
+          gas_used?: number | null
+          hash?: string | null
+          timestamp?: string | null
+          transaction_count?: number | null
         }
         Update: {
           block_number?: number
           created_at?: string
-          gas_used?: number
-          hash?: string
-          timestamp?: string
-          transaction_count?: number
+          gas_used?: number | null
+          hash?: string | null
+          timestamp?: string | null
+          transaction_count?: number | null
         }
         Relationships: []
       }
-      cluster_configurations: {
+      cloud_instances: {
         Row: {
-          cluster_id: string
+          cpu_arch: string | null
+          cpu_cores: number
+          cpu_effective_cores: number | null
+          cpu_name: string | null
+          created_at: string
+          disk_name: string
+          disk_space: number | null
+          gpu_arch: string | null
+          gpu_count: number | null
+          gpu_memory: number | null
+          gpu_name: string | null
+          hourly_price: number
           id: number
-          instance_count: number
-          instance_type_id: number
+          instance_name: string
+          memory: number
+          mobo_name: string | null
+          provider_id: number
+          region: string
+          snapshot_date: string | null
         }
         Insert: {
-          cluster_id: string
+          cpu_arch?: string | null
+          cpu_cores: number
+          cpu_effective_cores?: number | null
+          cpu_name?: string | null
+          created_at?: string
+          disk_name: string
+          disk_space?: number | null
+          gpu_arch?: string | null
+          gpu_count?: number | null
+          gpu_memory?: number | null
+          gpu_name?: string | null
+          hourly_price: number
           id?: number
-          instance_count: number
-          instance_type_id: number
+          instance_name: string
+          memory: number
+          mobo_name?: string | null
+          provider_id: number
+          region: string
+          snapshot_date?: string | null
         }
         Update: {
-          cluster_id?: string
+          cpu_arch?: string | null
+          cpu_cores?: number
+          cpu_effective_cores?: number | null
+          cpu_name?: string | null
+          created_at?: string
+          disk_name?: string
+          disk_space?: number | null
+          gpu_arch?: string | null
+          gpu_count?: number | null
+          gpu_memory?: number | null
+          gpu_name?: string | null
+          hourly_price?: number
           id?: number
-          instance_count?: number
-          instance_type_id?: number
+          instance_name?: string
+          memory?: number
+          mobo_name?: string | null
+          provider_id?: number
+          region?: string
+          snapshot_date?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "cluster_configurations_cluster_id_clusters_id_fk"
+            foreignKeyName: "cloud_instances_provider_id_cloud_providers_id_fk"
+            columns: ["provider_id"]
+            isOneToOne: false
+            referencedRelation: "cloud_providers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cloud_providers: {
+        Row: {
+          created_at: string
+          display_name: string
+          id: number
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          display_name: string
+          id?: number
+          name: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string
+          id?: number
+          name?: string
+        }
+        Relationships: []
+      }
+      cluster_benchmarks: {
+        Row: {
+          benchmark_id: number
+          cluster_id: string
+          cost_usd: number
+          created_at: string
+          id: number
+          time_ms: number
+        }
+        Insert: {
+          benchmark_id: number
+          cluster_id: string
+          cost_usd: number
+          created_at?: string
+          id?: number
+          time_ms: number
+        }
+        Update: {
+          benchmark_id?: number
+          cluster_id?: string
+          cost_usd?: number
+          created_at?: string
+          id?: number
+          time_ms?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cluster_benchmarks_benchmark_id_benchmarks_id_fk"
+            columns: ["benchmark_id"]
+            isOneToOne: false
+            referencedRelation: "benchmarks"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cluster_benchmarks_cluster_id_clusters_id_fk"
+            columns: ["cluster_id"]
+            isOneToOne: false
+            referencedRelation: "cluster_summary"
+            referencedColumns: ["cluster_id"]
+          },
+          {
+            foreignKeyName: "cluster_benchmarks_cluster_id_clusters_id_fk"
+            columns: ["cluster_id"]
+            isOneToOne: false
+            referencedRelation: "clusters"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cluster_machines: {
+        Row: {
+          cloud_instance_count: number
+          cloud_instance_id: number
+          cluster_version_id: number
+          id: number
+          machine_count: number | null
+          machine_id: number | null
+        }
+        Insert: {
+          cloud_instance_count: number
+          cloud_instance_id: number
+          cluster_version_id: number
+          id?: number
+          machine_count?: number | null
+          machine_id?: number | null
+        }
+        Update: {
+          cloud_instance_count?: number
+          cloud_instance_id?: number
+          cluster_version_id?: number
+          id?: number
+          machine_count?: number | null
+          machine_id?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cluster_machines_cloud_instance_id_cloud_instances_id_fk"
+            columns: ["cloud_instance_id"]
+            isOneToOne: false
+            referencedRelation: "cloud_instances"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cluster_machines_cluster_version_id_cluster_versions_id_fk"
+            columns: ["cluster_version_id"]
+            isOneToOne: false
+            referencedRelation: "cluster_versions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cluster_machines_machine_id_machines_id_fk"
+            columns: ["machine_id"]
+            isOneToOne: false
+            referencedRelation: "machines"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cluster_versions: {
+        Row: {
+          cluster_id: string
+          created_at: string
+          description: string | null
+          id: number
+          version: string
+          zkvm_version_id: number
+        }
+        Insert: {
+          cluster_id: string
+          created_at?: string
+          description?: string | null
+          id?: number
+          version: string
+          zkvm_version_id: number
+        }
+        Update: {
+          cluster_id?: string
+          created_at?: string
+          description?: string | null
+          id?: number
+          version?: string
+          zkvm_version_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cluster_versions_cluster_id_clusters_id_fk"
+            columns: ["cluster_id"]
+            isOneToOne: false
+            referencedRelation: "cluster_summary"
+            referencedColumns: ["cluster_id"]
+          },
+          {
+            foreignKeyName: "cluster_versions_cluster_id_clusters_id_fk"
             columns: ["cluster_id"]
             isOneToOne: false
             referencedRelation: "clusters"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "cluster_configurations_instance_type_id_aws_instance_pricing_id"
-            columns: ["instance_type_id"]
+            foreignKeyName: "cluster_versions_zkvm_version_id_zkvm_versions_id_fk"
+            columns: ["zkvm_version_id"]
             isOneToOne: false
-            referencedRelation: "aws_instance_pricing"
+            referencedRelation: "zkvm_versions"
             referencedColumns: ["id"]
           },
         ]
@@ -177,8 +371,12 @@ export type Database = {
           hardware: string | null
           id: string
           index: number | null
+          is_active: boolean
+          is_multi_machine: boolean
+          is_open_source: boolean
           nickname: string
           proof_type: string | null
+          software_link: string | null
           team_id: string
         }
         Insert: {
@@ -188,8 +386,12 @@ export type Database = {
           hardware?: string | null
           id?: string
           index?: number | null
+          is_active?: boolean
+          is_multi_machine?: boolean
+          is_open_source?: boolean
           nickname: string
           proof_type?: string | null
+          software_link?: string | null
           team_id: string
         }
         Update: {
@@ -199,8 +401,12 @@ export type Database = {
           hardware?: string | null
           id?: string
           index?: number | null
+          is_active?: boolean
+          is_multi_machine?: boolean
+          is_open_source?: boolean
           nickname?: string
           proof_type?: string | null
+          software_link?: string | null
           team_id?: string
         }
         Relationships: [
@@ -220,6 +426,54 @@ export type Database = {
           },
         ]
       }
+      machines: {
+        Row: {
+          cpu_cores: number | null
+          cpu_model: string | null
+          created_at: string
+          gpu_count: number[] | null
+          gpu_memory_gb: number[] | null
+          gpu_models: string[] | null
+          id: number
+          memory_count: number[] | null
+          memory_size_gb: number[] | null
+          memory_type: string[] | null
+          network_between_machines: string | null
+          storage_size_gb: number | null
+          total_tera_flops: number | null
+        }
+        Insert: {
+          cpu_cores?: number | null
+          cpu_model?: string | null
+          created_at?: string
+          gpu_count?: number[] | null
+          gpu_memory_gb?: number[] | null
+          gpu_models?: string[] | null
+          id?: number
+          memory_count?: number[] | null
+          memory_size_gb?: number[] | null
+          memory_type?: string[] | null
+          network_between_machines?: string | null
+          storage_size_gb?: number | null
+          total_tera_flops?: number | null
+        }
+        Update: {
+          cpu_cores?: number | null
+          cpu_model?: string | null
+          created_at?: string
+          gpu_count?: number[] | null
+          gpu_memory_gb?: number[] | null
+          gpu_models?: string[] | null
+          id?: number
+          memory_count?: number[] | null
+          memory_size_gb?: number[] | null
+          memory_type?: string[] | null
+          network_between_machines?: string | null
+          storage_size_gb?: number | null
+          total_tera_flops?: number | null
+        }
+        Relationships: []
+      }
       programs: {
         Row: {
           created_at: string
@@ -238,33 +492,10 @@ export type Database = {
         }
         Relationships: []
       }
-      proof_binaries: {
-        Row: {
-          proof_binary: string
-          proof_id: number
-        }
-        Insert: {
-          proof_binary: string
-          proof_id: number
-        }
-        Update: {
-          proof_binary?: string
-          proof_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "proof_binaries_proof_id_proofs_proof_id_fk"
-            columns: ["proof_id"]
-            isOneToOne: true
-            referencedRelation: "proofs"
-            referencedColumns: ["proof_id"]
-          },
-        ]
-      }
       proofs: {
         Row: {
           block_number: number
-          cluster_id: string
+          cluster_version_id: number
           created_at: string
           program_id: number | null
           proof_id: number
@@ -279,7 +510,7 @@ export type Database = {
         }
         Insert: {
           block_number: number
-          cluster_id: string
+          cluster_version_id: number
           created_at?: string
           program_id?: number | null
           proof_id?: number
@@ -294,7 +525,7 @@ export type Database = {
         }
         Update: {
           block_number?: number
-          cluster_id?: string
+          cluster_version_id?: number
           created_at?: string
           program_id?: number | null
           proof_id?: number
@@ -316,10 +547,10 @@ export type Database = {
             referencedColumns: ["block_number"]
           },
           {
-            foreignKeyName: "proofs_cluster_id_clusters_id_fk"
-            columns: ["cluster_id"]
+            foreignKeyName: "proofs_cluster_version_id_cluster_versions_id_fk"
+            columns: ["cluster_version_id"]
             isOneToOne: false
-            referencedRelation: "clusters"
+            referencedRelation: "cluster_versions"
             referencedColumns: ["id"]
           },
           {
@@ -338,6 +569,84 @@ export type Database = {
           },
           {
             foreignKeyName: "proofs_team_id_teams_id_fk"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams_summary"
+            referencedColumns: ["team_id"]
+          },
+        ]
+      }
+      proofs_daily_stats: {
+        Row: {
+          avg_cost: number
+          avg_latency: number
+          date: string
+          id: number
+          median_cost: number
+          median_latency: number
+          total_proofs: number
+        }
+        Insert: {
+          avg_cost: number
+          avg_latency: number
+          date: string
+          id?: number
+          median_cost: number
+          median_latency: number
+          total_proofs: number
+        }
+        Update: {
+          avg_cost?: number
+          avg_latency?: number
+          date?: string
+          id?: number
+          median_cost?: number
+          median_latency?: number
+          total_proofs?: number
+        }
+        Relationships: []
+      }
+      prover_daily_stats: {
+        Row: {
+          avg_cost: number
+          avg_latency: number
+          date: string
+          id: number
+          median_cost: number
+          median_latency: number
+          team_id: string
+          total_proofs: number
+        }
+        Insert: {
+          avg_cost: number
+          avg_latency: number
+          date: string
+          id?: number
+          median_cost: number
+          median_latency: number
+          team_id: string
+          total_proofs: number
+        }
+        Update: {
+          avg_cost?: number
+          avg_latency?: number
+          date?: string
+          id?: number
+          median_cost?: number
+          median_latency?: number
+          team_id?: string
+          total_proofs?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prover_daily_stats_team_id_teams_id_fk"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "prover_daily_stats_team_id_teams_id_fk"
             columns: ["team_id"]
             isOneToOne: false
             referencedRelation: "teams_summary"
@@ -396,48 +705,259 @@ export type Database = {
       }
       teams: {
         Row: {
+          chat_id: string | null
           created_at: string
           github_org: string | null
           id: string
           logo_url: string | null
           name: string
+          slug: string
+          storage_quota_bytes: number | null
           twitter_handle: string | null
           website_url: string | null
         }
         Insert: {
+          chat_id?: string | null
           created_at?: string
           github_org?: string | null
           id: string
           logo_url?: string | null
           name: string
+          slug: string
+          storage_quota_bytes?: number | null
           twitter_handle?: string | null
           website_url?: string | null
         }
         Update: {
+          chat_id?: string | null
           created_at?: string
           github_org?: string | null
           id?: string
           logo_url?: string | null
           name?: string
+          slug?: string
+          storage_quota_bytes?: number | null
           twitter_handle?: string | null
           website_url?: string | null
         }
+        Relationships: []
+      }
+      zkvm_performance_metrics: {
+        Row: {
+          created_at: string
+          id: number
+          size_bytes: number
+          updated_at: string
+          verification_ms: number
+          zkvm_id: number
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          size_bytes: number
+          updated_at?: string
+          verification_ms: number
+          zkvm_id: number
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          size_bytes?: number
+          updated_at?: string
+          verification_ms?: number
+          zkvm_id?: number
+        }
         Relationships: [
           {
-            foreignKeyName: "teams_id_users_id_fk"
-            columns: ["id"]
+            foreignKeyName: "zkvm_performance_metrics_zkvm_id_zkvms_id_fk"
+            columns: ["zkvm_id"]
             isOneToOne: true
-            referencedRelation: "users"
+            referencedRelation: "zkvms"
             referencedColumns: ["id"]
+          },
+        ]
+      }
+      zkvm_security_metrics: {
+        Row: {
+          created_at: string
+          evm_stf_bytecode: Database["public"]["Enums"]["severity_level"]
+          id: number
+          implementation_soundness: Database["public"]["Enums"]["severity_level"]
+          max_bounty_amount: number
+          protocol_soundness: Database["public"]["Enums"]["severity_level"]
+          quantum_security: Database["public"]["Enums"]["severity_level"]
+          security_target_bits: number
+          trusted_setup: boolean
+          updated_at: string
+          zkvm_id: number
+        }
+        Insert: {
+          created_at?: string
+          evm_stf_bytecode: Database["public"]["Enums"]["severity_level"]
+          id?: number
+          implementation_soundness: Database["public"]["Enums"]["severity_level"]
+          max_bounty_amount: number
+          protocol_soundness: Database["public"]["Enums"]["severity_level"]
+          quantum_security: Database["public"]["Enums"]["severity_level"]
+          security_target_bits: number
+          trusted_setup?: boolean
+          updated_at?: string
+          zkvm_id: number
+        }
+        Update: {
+          created_at?: string
+          evm_stf_bytecode?: Database["public"]["Enums"]["severity_level"]
+          id?: number
+          implementation_soundness?: Database["public"]["Enums"]["severity_level"]
+          max_bounty_amount?: number
+          protocol_soundness?: Database["public"]["Enums"]["severity_level"]
+          quantum_security?: Database["public"]["Enums"]["severity_level"]
+          security_target_bits?: number
+          trusted_setup?: boolean
+          updated_at?: string
+          zkvm_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "zkvm_security_metrics_zkvm_id_zkvms_id_fk"
+            columns: ["zkvm_id"]
+            isOneToOne: true
+            referencedRelation: "zkvms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      zkvm_versions: {
+        Row: {
+          created_at: string
+          id: number
+          release_date: string | null
+          version: string
+          zkvm_id: number
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          release_date?: string | null
+          version: string
+          zkvm_id: number
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          release_date?: string | null
+          version?: string
+          zkvm_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "zkvm_versions_zkvm_id_zkvms_id_fk"
+            columns: ["zkvm_id"]
+            isOneToOne: false
+            referencedRelation: "zkvms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      zkvms: {
+        Row: {
+          continuations: boolean
+          created_at: string
+          dual_licenses: boolean
+          frontend: string
+          id: number
+          is_open_source: boolean
+          is_proving_mainnet: boolean
+          isa: string
+          name: string
+          parallelizable_proving: boolean
+          precompiles: boolean
+          repo_url: string
+          slug: string
+          team_id: string
+        }
+        Insert: {
+          continuations?: boolean
+          created_at?: string
+          dual_licenses?: boolean
+          frontend: string
+          id?: number
+          is_open_source?: boolean
+          is_proving_mainnet?: boolean
+          isa: string
+          name: string
+          parallelizable_proving?: boolean
+          precompiles?: boolean
+          repo_url: string
+          slug: string
+          team_id: string
+        }
+        Update: {
+          continuations?: boolean
+          created_at?: string
+          dual_licenses?: boolean
+          frontend?: string
+          id?: number
+          is_open_source?: boolean
+          is_proving_mainnet?: boolean
+          isa?: string
+          name?: string
+          parallelizable_proving?: boolean
+          precompiles?: boolean
+          repo_url?: string
+          slug?: string
+          team_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "zkvms_team_id_teams_id_fk"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "zkvms_team_id_teams_id_fk"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams_summary"
+            referencedColumns: ["team_id"]
           },
         ]
       }
     }
     Views: {
+      cluster_summary: {
+        Row: {
+          avg_cost_per_proof: number | null
+          avg_proving_time: number | null
+          cluster_id: string | null
+          cluster_nickname: string | null
+          team_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "clusters_team_id_teams_id_fk"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "clusters_team_id_teams_id_fk"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "teams_summary"
+            referencedColumns: ["team_id"]
+          },
+        ]
+      }
       recent_summary: {
         Row: {
           avg_cost_per_proof: number | null
           avg_proving_time: number | null
+          median_cost_per_proof: number | null
+          median_proving_time: number | null
           total_proven_blocks: number | null
         }
         Relationships: []
@@ -445,23 +965,30 @@ export type Database = {
       teams_summary: {
         Row: {
           avg_cost_per_proof: number | null
+          avg_cost_per_proof_multi: number | null
+          avg_cost_per_proof_single: number | null
           avg_proving_time: number | null
+          avg_proving_time_multi: number | null
+          avg_proving_time_single: number | null
           logo_url: string | null
           team_id: string | null
           team_name: string | null
+          total_proofs: number | null
+          total_proofs_multi: number | null
+          total_proofs_single: number | null
         }
-        Relationships: [
-          {
-            foreignKeyName: "teams_id_users_id_fk"
-            columns: ["team_id"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
     }
     Functions: {
+      escape_markdown_v2: {
+        Args: { input_text: string }
+        Returns: string
+      }
+      get_telegram_bot_token: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       is_allowed_apikey: {
         Args: {
           apikey: string
@@ -469,9 +996,38 @@ export type Database = {
         }
         Returns: boolean
       }
+      populate_missing_proofs_temp: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
+      send_internal_summary: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      send_internal_summary_from_temp: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      send_team_alerts: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      send_team_alerts_from_temp: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      send_telegram_message: {
+        Args: { bot_token: string; chat_id: string; message_text: string }
+        Returns: Record<string, unknown>
+      }
+      update_cluster_active_status: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
     }
     Enums: {
-      key_mode: "read" | "write" | "all" | "upload"
+      key_mode: "admin" | "read" | "write"
+      severity_level: "red" | "yellow" | "green"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -479,27 +1035,33 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -507,20 +1069,24 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -528,20 +1094,24 @@ export type TablesInsert<
     : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -549,15 +1119,47 @@ export type TablesUpdate<
     : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
-    | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {
+      key_mode: ["admin", "read", "write"],
+      severity_level: ["red", "yellow", "green"],
+    },
+  },
+} as const

--- a/scripts/migrate-proof-binaries-bucket.ts
+++ b/scripts/migrate-proof-binaries-bucket.ts
@@ -1,0 +1,280 @@
+/**
+ * Migration script to copy all proof binary files from the old bucket
+ * (proof_binaries) to the new bucket (proof-binaries)
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-proof-binaries-bucket.ts [--dry-run]
+ *
+ * Options:
+ *   --dry-run    List files that would be copied without actually copying them
+ *   --delete-old Delete files from old bucket after successful copy (use with caution!)
+ */
+
+import { createClient } from "@supabase/supabase-js"
+
+const OLD_BUCKET = "proof_binaries"
+const NEW_BUCKET = "proof-binaries"
+
+// Check for required environment variables
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error("Error: Missing required environment variables")
+  console.error("Required:")
+  console.error("  - NEXT_PUBLIC_SUPABASE_URL")
+  console.error("  - SUPABASE_SERVICE_ROLE_KEY")
+  process.exit(1)
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const isDryRun = args.includes("--dry-run")
+const deleteOld = args.includes("--delete-old")
+
+if (deleteOld && isDryRun) {
+  console.error("Error: Cannot use --delete-old with --dry-run")
+  process.exit(1)
+}
+
+// Create Supabase client with service role key
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+})
+
+async function listAllFiles(bucket: string): Promise<string[]> {
+  const allFiles: string[] = []
+  let offset = 0
+  const limit = 1000
+  let hasMore = true
+
+  while (hasMore) {
+    const { data, error } = await supabase.storage
+      .from(bucket)
+      .list("", { limit, offset })
+
+    if (error) {
+      throw new Error(`Failed to list files in ${bucket}: ${error.message}`)
+    }
+
+    if (!data || data.length === 0) {
+      hasMore = false
+      break
+    }
+
+    allFiles.push(...data.map((file) => file.name))
+    offset += data.length
+
+    if (data.length < limit) {
+      hasMore = false
+    }
+  }
+
+  return allFiles
+}
+
+async function copyFile(filename: string): Promise<boolean> {
+  try {
+    // Download from old bucket
+    const { data: fileData, error: downloadError } = await supabase.storage
+      .from(OLD_BUCKET)
+      .download(filename)
+
+    if (downloadError) {
+      console.error(
+        `  ✗ Failed to download ${filename}: ${downloadError.message}`
+      )
+      return false
+    }
+
+    if (!fileData) {
+      console.error(`  ✗ No data received for ${filename}`)
+      return false
+    }
+
+    // Convert blob to buffer
+    const arrayBuffer = await fileData.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    // Rename .txt files to .bin
+    const newFilename = filename.endsWith(".txt")
+      ? filename.replace(/\.txt$/, ".bin")
+      : filename
+
+    // Upload to new bucket with new filename
+    const { error: uploadError } = await supabase.storage
+      .from(NEW_BUCKET)
+      .upload(newFilename, buffer, {
+        contentType: "application/octet-stream",
+        upsert: true,
+      })
+
+    if (uploadError) {
+      console.error(
+        `  ✗ Failed to upload ${newFilename}: ${uploadError.message}`
+      )
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.error(`  ✗ Error copying ${filename}:`, error)
+    return false
+  }
+}
+
+async function deleteFile(filename: string): Promise<boolean> {
+  try {
+    const { error } = await supabase.storage.from(OLD_BUCKET).remove([filename])
+
+    if (error) {
+      console.error(`  ✗ Failed to delete ${filename}: ${error.message}`)
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.error(`  ✗ Error deleting ${filename}:`, error)
+    return false
+  }
+}
+
+async function migrate() {
+  console.log("🚀 Proof Binaries Bucket Migration")
+  console.log(`   From: ${OLD_BUCKET}`)
+  console.log(`   To: ${NEW_BUCKET}`)
+  if (isDryRun) {
+    console.log("   Mode: DRY RUN (no changes will be made)")
+  }
+  if (deleteOld) {
+    console.log("   ⚠️  Delete old files: ENABLED")
+  }
+  console.log()
+
+  // Verify new bucket exists
+  console.log("📋 Verifying buckets...")
+  const { data: buckets, error: bucketsError } =
+    await supabase.storage.listBuckets()
+
+  if (bucketsError) {
+    console.error("✗ Failed to list buckets:", bucketsError.message)
+    process.exit(1)
+  }
+  console.log("buckets found:", buckets)
+  const oldBucketExists = buckets?.some((b) => b.name === OLD_BUCKET)
+  const newBucketExists = buckets?.some((b) => b.name === NEW_BUCKET)
+
+  if (!oldBucketExists) {
+    console.error(`✗ Old bucket '${OLD_BUCKET}' not found`)
+    process.exit(1)
+  }
+
+  if (!newBucketExists) {
+    console.error(`✗ New bucket '${NEW_BUCKET}' not found`)
+    console.error(
+      "  Please create the new bucket first via Supabase dashboard or CLI"
+    )
+    process.exit(1)
+  }
+
+  console.log(`✓ Old bucket '${OLD_BUCKET}' exists`)
+  console.log(`✓ New bucket '${NEW_BUCKET}' exists`)
+  console.log()
+
+  // List all files
+  console.log("📂 Listing files in old bucket...")
+  const files = await listAllFiles(OLD_BUCKET)
+  console.log(`   Found ${files.length} files`)
+  console.log()
+
+  if (files.length === 0) {
+    console.log("✓ No files to migrate")
+    return
+  }
+
+  if (isDryRun) {
+    console.log("📝 Files that would be copied:")
+    files.forEach((file) => console.log(`   - ${file}`))
+    console.log()
+    console.log(`✓ Dry run complete. Would copy ${files.length} files.`)
+    return
+  }
+
+  // Copy files
+  console.log("📦 Copying files...")
+  let successCount = 0
+  let failCount = 0
+  const failedFiles: string[] = []
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    const newFilename = file.endsWith(".txt")
+      ? file.replace(/\.txt$/, ".bin")
+      : file
+    const renamed = file !== newFilename
+
+    process.stdout.write(
+      `   [${i + 1}/${files.length}] Copying ${file}${renamed ? ` → ${newFilename}` : ""}...`
+    )
+
+    const success = await copyFile(file)
+
+    if (success) {
+      successCount++
+      console.log(" ✓")
+
+      // Delete old file if requested
+      if (deleteOld) {
+        process.stdout.write(
+          `   [${i + 1}/${files.length}] Deleting ${file} from old bucket...`
+        )
+        const deleted = await deleteFile(file)
+        if (deleted) {
+          console.log(" ✓")
+        } else {
+          console.log(" ✗ (copy succeeded but delete failed)")
+        }
+      }
+    } else {
+      failCount++
+      failedFiles.push(file)
+      console.log(" ✗")
+    }
+  }
+
+  console.log()
+  console.log("📊 Migration Summary:")
+  console.log(`   Total files: ${files.length}`)
+  console.log(`   Successful: ${successCount}`)
+  console.log(`   Failed: ${failCount}`)
+
+  if (failedFiles.length > 0) {
+    console.log()
+    console.log("❌ Failed files:")
+    failedFiles.forEach((file) => console.log(`   - ${file}`))
+  }
+
+  console.log()
+  if (failCount === 0) {
+    console.log("✅ Migration completed successfully!")
+    if (deleteOld) {
+      console.log(`   Old bucket '${OLD_BUCKET}' has been cleaned up`)
+    } else {
+      console.log(`   Old bucket '${OLD_BUCKET}' still contains original files`)
+      console.log(`   You can delete it manually after verifying the migration`)
+    }
+  } else {
+    console.log("⚠️  Migration completed with errors")
+    console.log("   Please review failed files and retry if needed")
+    process.exit(1)
+  }
+}
+
+// Run migration
+migrate().catch((error) => {
+  console.error("💥 Fatal error:", error)
+  process.exit(1)
+})

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -78,7 +78,7 @@ file_size_limit = "50MiB"
 enabled = true
 
 # Uncomment to configure local storage buckets
-[storage.buckets.proof_binaries]
+[storage.buckets.proof-binaries]
 public = true
 file_size_limit = "50MiB"
 allowed_mime_types = ["text/plain", "application/octet-stream"]


### PR DESCRIPTION
Storage buckets on Supabase should not be named with an underscore. This PR coordinates the migration to a new bucket called `proof-binaries`. It seems like tech debt best to address now before the demo.

In addition, uploaded proofs have previously been given the .txt extension. This PR copies existing proofs using the correct .bin extension and all future proofs will be uploaded correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded database schema with many new tables, relationships, views and aggregation functions for infrastructure, team management, and proof analytics

* **Chores**
  * Renamed storage bucket to a hyphenated convention
  * Added a migration tool to copy files from the old bucket to the new one (supports dry-run and optional cleanup)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->