### PR TITLE
chore: remove completed mobile responsiveness TODO

### DIFF
--- a/components/ClusterProofRow.tsx
+++ b/components/ClusterProofRow.tsx
@@ -42,7 +42,6 @@ export const ClusterProofRow = ({ proof }: ClusterProofRowProps) => {
       ? costPerProof / (proof.block.gas_used / 1e6)
       : null
 
-  // TODO:TEAM - mobile responsiveness
   return (
     <div
       data-grid-template-areas="cluster-proof"


### PR DESCRIPTION
The component already has full responsive breakpoints (`grid-cols-[auto_auto]` → md → lg → xl) with proper gap handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal cleanup and code maintenance.

---

**Note:** This release contains no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->