### PR TITLE
fix: remove duplicate parameter destructuring in getActiveClusters

### DIFF
--- a/lib/api/clusters.ts
+++ b/lib/api/clusters.ts
@@ -58,8 +58,7 @@ export const getActiveClusters = async (filters?: {
   teamId?: string
   zkvmId?: number
 }) => {
-  const { teamId, zkvmId } = filters ?? {}
-  const cacheKey = `active-clusters-${teamId}-${zkvmId}`
+  const cacheKey = `active-clusters-${filters?.teamId}-${filters?.zkvmId}`
 
   return cache(
     async (filters?: { teamId?: string; zkvmId?: number }) => {


### PR DESCRIPTION
Removed redundant destructuring of filters parameter in getActiveClusters function. 

The parameters were being destructured twice - once for cache key generation and again inside the cached function. 

Now using optional chaining for cache key creation while keeping destructuring only where the values are actually used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal optimization of cluster data retrieval logic with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->