### PR TITLE
fix: remove unused imports from clusters.ts

### DIFF
--- a/lib/api/clusters.ts
+++ b/lib/api/clusters.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, exists, gt, sql, sum } from "drizzle-orm"
+import { and, desc, eq, exists, sql, sum } from "drizzle-orm"
 import { unstable_cache as cache } from "next/cache"
 
 import { TAGS } from "@/lib/constants"
@@ -8,7 +8,6 @@ import {
   clusterMachines,
   clusters,
   clusterVersions,
-  proofs,
   teams,
   zkvms,
   zkvmVersions,


### PR DESCRIPTION
Remove unused `gt` operator and `proofs` table imports from clusters API file.
These imports were not referenced anywhere in the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal imports and dependencies for improved maintainability and reduced public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->