### PR TITLE
Config connection pool limits

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -11,8 +11,13 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is not set")
 }
 
-// Disable prefetch as it is not supported for "Transaction" pool mode
-const client = postgres(process.env.DATABASE_URL, { prepare: false })
+// Configured for Supabase Shared Pooler (Transaction mode) with IPv4 support
+const client = postgres(process.env.DATABASE_URL, {
+  prepare: false, // Required for Supabase Transaction pooler mode
+  max: 3, // Maximum connections per serverless instance
+  idle_timeout: 10, // Netlify serverless function idle timeout
+  max_lifetime: 60 * 10, // Close connections after 10 minutes (shorter for serverless)
+})
 
 export const db = drizzle({
   client,


### PR DESCRIPTION
Fixes "Max client connections reached" errors by adding connection pool configuration to the postgres client.

- Set `max: 3` connections per serverless instance
- Configure `idle_timeout: 10s` and `max_lifetime: 10m` for serverless environments

Prevents connection exhaustion when multiple serverless instances run concurrently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database connection pool configuration for improved performance and reliability during high-traffic periods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->