### PR TITLE
fix: twitter hundle and website link snarkify

### DIFF
--- a/supabase/seed/seed.ts
+++ b/supabase/seed/seed.ts
@@ -37,7 +37,7 @@ const proversProfiles = [
     logo_url:
       "https://ibkqxhjnroghhtfyualc.supabase.co/storage/v1/object/public/public-assets/snarkify-logo.svg",
     website_url: "https://snarkify.io",
-    twitter_handle: "Snarkify_ZKP",
+    twitter_handle: "snarkify_zkp",
     github_org: "snarkify",
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated seed/profile data for Snarkify: website changed to https://snarkify.io and Twitter handle updated to snarkify_zkp. This is a data-only update to seed information; no functional or exported API changes were made.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->