### PR TITLE
fix(api): handle concurrent proof submission race condition

### DIFF
--- a/app/api/v0/proofs/proved/route.ts
+++ b/app/api/v0/proofs/proved/route.ts
@@ -127,6 +127,17 @@ export const POST = withAuthAndRateLimit(
           })
           .returning({ proof_id: proofs.proof_id })
 
+        // newProof is undefined when a concurrent request already set status to
+        // "proved" between our existingProof check above and this insert — the
+        // onConflictDoUpdate WHERE clause (ne proof_status "proved") prevents the
+        // update, so RETURNING returns an empty array.
+        if (!newProof) {
+          console.log(
+            `[Proved] Concurrent request already proved block ${block_number} for cluster ${cluster.id}`
+          )
+          return undefined
+        }
+
         // Handle active cluster status and updates
         if (!clusterVersion.cluster.is_active) {
           await tx
@@ -143,6 +154,10 @@ export const POST = withAuthAndRateLimit(
 
         return newProof
       })
+
+      if (!newProof) {
+        return new Response("Proof already proved", { status: 409 })
+      }
 
       revalidateTag(TAGS.PROOFS)
       revalidateTag(TAGS.BLOCKS)


### PR DESCRIPTION
Two requests for the same block could slip through simultaneously and cause a crash when the second one tried to access newProof.proof_id on an undefined value. Added a guard to return 409 instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition handling in proof API to prevent duplicate proof submissions when multiple concurrent requests occur simultaneously. The API now properly detects conflicts and returns an appropriate error response instead of attempting redundant operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ethproofs/ethproofs/pull/582)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->