### PR TITLE
feat: add precompile indication to charts and filters

### DIFF
--- a/components/csp-benchmarks/bar-charts.tsx
+++ b/components/csp-benchmarks/bar-charts.tsx
@@ -18,6 +18,12 @@ import {
   getProverKey,
   metricConfigs,
 } from "./metrics"
+import {
+  getPrecompileLabel,
+  getPrecompileProvers,
+  hasPrecompileMeasurements,
+  precompileFootnoteText,
+} from "./precompiles.utils"
 import { ChartCard, EmptyState } from "./shared"
 
 import type { Metrics } from "@/lib/api/csp-benchmarks"
@@ -104,6 +110,8 @@ interface BarMetricChartProps {
   label?: string
   ariaLabel?: string
   totalProvers: number
+  precompileLabels: Map<string, string>
+  shouldShowPrecompileFootnote: boolean
 }
 
 function BarMetricChart({
@@ -116,6 +124,8 @@ function BarMetricChart({
   label,
   ariaLabel,
   totalProvers,
+  precompileLabels,
+  shouldShowPrecompileFootnote,
 }: BarMetricChartProps) {
   const chartHeight = computeBarChartHeight(totalProvers)
 
@@ -127,6 +137,20 @@ function BarMetricChart({
     [formatValue]
   )
 
+  const yAxisTickFormatter = useCallback(
+    (value: unknown) =>
+      typeof value === "string"
+        ? (precompileLabels.get(value) ?? value)
+        : String(value),
+    [precompileLabels]
+  )
+
+  const footer = shouldShowPrecompileFootnote ? (
+    <p className="mt-3 text-xs text-muted-foreground">
+      {precompileFootnoteText}
+    </p>
+  ) : null
+
   return (
     <ChartCard
       title={title}
@@ -134,6 +158,7 @@ function BarMetricChart({
       height={chartHeight}
       label={label}
       ariaLabel={ariaLabel}
+      footer={footer}
     >
       <ChartContainer
         config={chartConfig}
@@ -159,6 +184,7 @@ function BarMetricChart({
             tickMargin={4}
             axisLine={false}
             tick={barYAxisTickStyle}
+            tickFormatter={yAxisTickFormatter}
             width={90}
           />
           <Bar
@@ -185,6 +211,23 @@ export function BarCharts({
   const filteredData = useMemo(
     () => benchmarks.filter((b) => b.input_size === selectedInputSize),
     [benchmarks, selectedInputSize]
+  )
+  const precompileProvers = useMemo(
+    () => getPrecompileProvers(filteredData),
+    [filteredData]
+  )
+  const precompileLabels = useMemo(() => {
+    const labels = new Map<string, string>()
+
+    for (const prover of allProvers) {
+      labels.set(prover, getPrecompileLabel(prover, precompileProvers))
+    }
+
+    return labels
+  }, [allProvers, precompileProvers])
+  const shouldShowPrecompileFootnote = useMemo(
+    () => hasPrecompileMeasurements(filteredData),
+    [filteredData]
   )
 
   const allMetricsData = useMemo(() => {
@@ -248,6 +291,8 @@ export function BarCharts({
             label={chartLabel}
             ariaLabel={`${config.label} comparison`}
             totalProvers={allProvers.length}
+            precompileLabels={precompileLabels}
+            shouldShowPrecompileFootnote={shouldShowPrecompileFootnote}
           />
         </div>
       ))}

--- a/components/csp-benchmarks/columns.tsx
+++ b/components/csp-benchmarks/columns.tsx
@@ -261,11 +261,17 @@ export function getColumns(options?: CspColumnsOptions): ColumnDef<Metrics>[] {
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="name" />
       ),
-      cell: ({ row }) => (
-        <div style={{ width: 100 }}>
-          <span className="font-medium">{row.original.name}</span>
-        </div>
-      ),
+      cell: ({ row }) => {
+        const name = row.original.uses_precompile
+          ? `${row.original.name}*`
+          : row.original.name
+
+        return (
+          <div style={{ width: 100 }}>
+            <span className="font-medium">{name}</span>
+          </div>
+        )
+      },
     },
     {
       id: "actions",

--- a/components/csp-benchmarks/line-charts.tsx
+++ b/components/csp-benchmarks/line-charts.tsx
@@ -20,6 +20,12 @@ import {
   nanosecondsPerMillisecond,
 } from "./metrics"
 import {
+  getPrecompileLabel,
+  getPrecompileProvers,
+  hasPrecompileMeasurements,
+  precompileFootnoteText,
+} from "./precompiles.utils"
+import {
   ChartCard,
   ChartLegend,
   ChartTooltipBody,
@@ -132,6 +138,8 @@ interface LineMetricChartProps {
   isBytes: boolean
   label?: string
   ariaLabel?: string
+  precompileLabels: Map<string, string>
+  shouldShowPrecompileFootnote: boolean
 }
 
 function LineMetricChart({
@@ -147,6 +155,8 @@ function LineMetricChart({
   isBytes,
   label,
   ariaLabel,
+  precompileLabels,
+  shouldShowPrecompileFootnote,
 }: LineMetricChartProps) {
   const ticks = useMemo(() => {
     const allValues = data.flatMap((point) =>
@@ -198,23 +208,41 @@ function LineMetricChart({
       payload?: ReadonlyArray<ChartTooltipBodyEntry>
     }) => {
       if (!active || !payload || payload.length === 0) return null
+      const labeledPayload = payload.map((entry) => ({
+        ...entry,
+        name:
+          typeof entry.name === "string"
+            ? (precompileLabels.get(entry.name) ?? entry.name)
+            : entry.name,
+      }))
       return (
-        <ChartTooltipBody entries={payload} formatValue={tooltipFormatter} />
+        <ChartTooltipBody
+          entries={labeledPayload}
+          formatValue={tooltipFormatter}
+        />
       )
     },
-    [tooltipFormatter]
+    [precompileLabels, tooltipFormatter]
   )
 
   if (ticks === null) return null
 
   const legendFooter = (
-    <ChartLegend
-      keys={seriesKeys}
-      chartConfig={chartConfig}
-      hiddenKeys={hiddenSeries}
-      onToggle={onToggleSeries}
-      className="mt-3"
-    />
+    <>
+      <ChartLegend
+        keys={seriesKeys}
+        chartConfig={chartConfig}
+        hiddenKeys={hiddenSeries}
+        onToggle={onToggleSeries}
+        labels={precompileLabels}
+        className="mt-3"
+      />
+      {shouldShowPrecompileFootnote && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          {precompileFootnoteText}
+        </p>
+      )}
+    </>
   )
 
   return (
@@ -277,6 +305,24 @@ export function LineCharts({
   chartConfig,
   inputSizeCount,
 }: LineChartsProps) {
+  const precompileProvers = useMemo(
+    () => getPrecompileProvers(benchmarks),
+    [benchmarks]
+  )
+  const precompileLabels = useMemo(() => {
+    const labels = new Map<string, string>()
+
+    for (const key of seriesKeys) {
+      labels.set(key, getPrecompileLabel(key, precompileProvers))
+    }
+
+    return labels
+  }, [precompileProvers, seriesKeys])
+  const shouldShowPrecompileFootnote = useMemo(
+    () => hasPrecompileMeasurements(benchmarks),
+    [benchmarks]
+  )
+
   const metricsData = useMemo(() => {
     if (inputSizeCount <= 1) return []
 
@@ -342,6 +388,8 @@ export function LineCharts({
           isBytes={config.unit === "bytes"}
           label={dataKeyToTarget[target]}
           ariaLabel={`${config.label} trend`}
+          precompileLabels={precompileLabels}
+          shouldShowPrecompileFootnote={shouldShowPrecompileFootnote}
         />
       ))}
     </div>

--- a/components/csp-benchmarks/precompiles.utils.ts
+++ b/components/csp-benchmarks/precompiles.utils.ts
@@ -1,0 +1,28 @@
+import { getProverKey } from "./metrics"
+
+import type { Metrics } from "@/lib/api/csp-benchmarks"
+
+export const precompileFootnoteText = "*uses precompiles"
+
+export function getPrecompileProvers(benchmarks: Metrics[]): Set<string> {
+  const result = new Set<string>()
+
+  for (const benchmark of benchmarks) {
+    if (benchmark.uses_precompile) {
+      result.add(getProverKey(benchmark))
+    }
+  }
+
+  return result
+}
+
+export function getPrecompileLabel(
+  key: string,
+  precompileProvers: Set<string>
+): string {
+  return precompileProvers.has(key) ? `${key}*` : key
+}
+
+export function hasPrecompileMeasurements(benchmarks: Metrics[]): boolean {
+  return benchmarks.some((benchmark) => benchmark.uses_precompile)
+}

--- a/components/csp-benchmarks/shared.tsx
+++ b/components/csp-benchmarks/shared.tsx
@@ -182,6 +182,7 @@ interface ChartLegendProps {
   hiddenKeys: Set<string>
   onToggle(key: string): void
   onHover?(key: string | null): void
+  labels?: Map<string, string>
   className?: string
 }
 
@@ -191,6 +192,7 @@ export function ChartLegend({
   hiddenKeys,
   onToggle,
   onHover,
+  labels,
   className,
 }: ChartLegendProps) {
   return (
@@ -202,6 +204,7 @@ export function ChartLegend({
     >
       {keys.map((key) => {
         const isHidden = hiddenKeys.has(key)
+        const label = labels?.get(key) ?? key
         return (
           <Toggle
             key={key}
@@ -209,7 +212,7 @@ export function ChartLegend({
             size="sm"
             pressed={!isHidden}
             onPressedChange={() => onToggle(key)}
-            aria-label={isHidden ? `show ${key}` : `hide ${key}`}
+            aria-label={isHidden ? `show ${label}` : `hide ${label}`}
             className={cn(
               "h-auto min-w-0 justify-start gap-1.5 rounded-sm px-2.5 py-1.5 text-xs focus-visible:ring-2 focus-visible:ring-ring md:gap-2 md:px-3 md:py-1.5 md:text-sm",
               isHidden && "line-through opacity-40"
@@ -223,7 +226,7 @@ export function ChartLegend({
               className="h-2.5 w-2.5 shrink-0 rounded-sm md:h-3 md:w-3"
               style={{ backgroundColor: chartConfig[key]?.color }}
             />
-            <span className="truncate">{key}</span>
+            <span className="truncate">{label}</span>
           </Toggle>
         )
       })}

--- a/components/csp-benchmarks/table-filters.tsx
+++ b/components/csp-benchmarks/table-filters.tsx
@@ -15,7 +15,18 @@ import { cn } from "@/lib/utils"
 
 import type { Metrics } from "@/lib/api/csp-benchmarks"
 
-type FilterValue = boolean | null
+const securityFilterAllValue = "all"
+const securityFilterMinimum100Value = "100+"
+const securityFilterMinimum128Value = "128+"
+const securityFilterKey = "security"
+const minimum100SecurityBits = 100
+const minimum128SecurityBits = 128
+
+type BooleanFilterValue = boolean | null
+type SecurityFilterValue =
+  | typeof securityFilterAllValue
+  | typeof securityFilterMinimum100Value
+  | typeof securityFilterMinimum128Value
 
 type BooleanFilterKey =
   | "is_zkvm"
@@ -24,15 +35,19 @@ type BooleanFilterKey =
   | "is_audited"
   | "is_maintained"
 
-type FilterState = Record<BooleanFilterKey, FilterValue>
+type SecurityFilterKey = typeof securityFilterKey
+type FilterKey = BooleanFilterKey | SecurityFilterKey
+type FilterValue = BooleanFilterValue | SecurityFilterValue
+type FilterState = Record<BooleanFilterKey, BooleanFilterValue> &
+  Record<SecurityFilterKey, SecurityFilterValue>
 
-const filterDefinitions: ReadonlyArray<{
+const booleanFilterDefinitions: ReadonlyArray<{
   key: BooleanFilterKey
   label: string
 }> = [
-  { key: "is_zkvm", label: "VM" },
   { key: "is_zk", label: "zero-knowledge" },
   { key: "is_pq", label: "post-quantum" },
+  { key: "is_zkvm", label: "VM" },
   { key: "is_audited", label: "audited" },
   { key: "is_maintained", label: "maintained" },
 ]
@@ -43,6 +58,7 @@ const initialFilterState: FilterState = {
   is_pq: null,
   is_audited: null,
   is_maintained: null,
+  security: securityFilterAllValue,
 }
 
 const auditedStatus = "audited"
@@ -61,9 +77,50 @@ function matchesFilter(
   return value ? field === true : field === false
 }
 
+function getSecurityThreshold(value: SecurityFilterValue): number | null {
+  if (value === securityFilterMinimum100Value) return minimum100SecurityBits
+  if (value === securityFilterMinimum128Value) return minimum128SecurityBits
+  return null
+}
+
+function matchesSecurityFilter(
+  row: Metrics,
+  value: SecurityFilterValue
+): boolean {
+  const threshold = getSecurityThreshold(value)
+  if (threshold === null) return true
+  return typeof row.security_bits === "number" && row.security_bits >= threshold
+}
+
+function updateFilterState(
+  filters: FilterState,
+  key: FilterKey,
+  value: FilterValue
+): FilterState {
+  if (key === securityFilterKey) {
+    if (typeof value !== "string") return filters
+    return { ...filters, security: value }
+  }
+
+  if (typeof value === "string") return filters
+  return { ...filters, [key]: value }
+}
+
+function getActiveFilterCount(filters: FilterState): number {
+  let count = filters.security === securityFilterAllValue ? 0 : 1
+
+  for (const { key } of booleanFilterDefinitions) {
+    if (filters[key] !== null) {
+      count += 1
+    }
+  }
+
+  return count
+}
+
 interface UseTableFiltersReturn {
   filters: FilterState
-  setFilter(key: BooleanFilterKey, value: FilterValue): void
+  setFilter(key: FilterKey, value: FilterValue): void
   activeCount: number
   applyFilters(benchmarks: Metrics[]): Metrics[]
 }
@@ -71,23 +128,21 @@ interface UseTableFiltersReturn {
 export function useTableFilters(): UseTableFiltersReturn {
   const [filters, setFilters] = useState<FilterState>(initialFilterState)
 
-  const setFilter = useCallback((key: BooleanFilterKey, value: FilterValue) => {
-    setFilters((prev) => ({ ...prev, [key]: value }))
+  const setFilter = useCallback((key: FilterKey, value: FilterValue) => {
+    setFilters((prev) => updateFilterState(prev, key, value))
   }, [])
 
-  const activeCount = useMemo(
-    () => Object.values(filters).filter((v) => v !== null).length,
-    [filters]
-  )
+  const activeCount = useMemo(() => getActiveFilterCount(filters), [filters])
 
   const applyFilters = useCallback(
     (benchmarks: Metrics[]) =>
-      benchmarks.filter((row) =>
-        filterDefinitions.every(({ key }) => {
-          const value = filters[key]
-          if (value === null) return true
-          return matchesFilter(row, key, value)
-        })
+      benchmarks.filter(
+        (row) =>
+          booleanFilterDefinitions.every(({ key }) => {
+            const value = filters[key]
+            if (value === null) return true
+            return matchesFilter(row, key, value)
+          }) && matchesSecurityFilter(row, filters.security)
       ),
     [filters]
   )
@@ -95,15 +150,37 @@ export function useTableFilters(): UseTableFiltersReturn {
   return { filters, setFilter, activeCount, applyFilters }
 }
 
-const segmentOptions: ReadonlyArray<{ label: string; value: FilterValue }> = [
+const segmentOptions: ReadonlyArray<{
+  label: string
+  value: BooleanFilterValue
+}> = [
   { label: "all", value: null },
   { label: "yes", value: true },
   { label: "no", value: false },
 ]
 
+const securitySegmentOptions: ReadonlyArray<{
+  label: SecurityFilterValue
+  value: SecurityFilterValue
+}> = [
+  { label: securityFilterAllValue, value: securityFilterAllValue },
+  {
+    label: securityFilterMinimum100Value,
+    value: securityFilterMinimum100Value,
+  },
+  {
+    label: securityFilterMinimum128Value,
+    value: securityFilterMinimum128Value,
+  },
+]
+
+const segmentGroupClass = "grid w-28 grid-cols-3 rounded-md border"
+const segmentButtonClass =
+  "px-0 py-0.5 text-center text-xs transition-colors first:rounded-l-[calc(theme(borderRadius.md)-1px)] last:rounded-r-[calc(theme(borderRadius.md)-1px)]"
+
 interface TableFiltersProps {
   filters: FilterState
-  setFilter(key: BooleanFilterKey, value: FilterValue): void
+  setFilter(key: FilterKey, value: FilterValue): void
   activeCount: number
 }
 
@@ -132,11 +209,11 @@ export function TableFilters({
       </PopoverTrigger>
       <PopoverContent align="start" className="w-64 p-3">
         <div className="flex flex-col gap-2">
-          {filterDefinitions.map(({ key, label }) => (
+          {booleanFilterDefinitions.slice(0, 2).map(({ key, label }) => (
             <div key={key} className="flex items-center justify-between">
               <span className="text-sm">{label}</span>
               <div
-                className="flex rounded-md border"
+                className={segmentGroupClass}
                 role="group"
                 aria-label={`${label} filter`}
               >
@@ -146,8 +223,59 @@ export function TableFilters({
                     type="button"
                     aria-pressed={filters[key] === option.value}
                     className={cn(
-                      "px-2 py-0.5 text-xs transition-colors",
-                      "first:rounded-l-[calc(theme(borderRadius.md)-1px)] last:rounded-r-[calc(theme(borderRadius.md)-1px)]",
+                      segmentButtonClass,
+                      filters[key] === option.value
+                        ? "bg-accent text-accent-foreground"
+                        : "bg-transparent hover:bg-accent/50"
+                    )}
+                    onClick={() => setFilter(key, option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+          <div className="flex items-center justify-between">
+            <span className="text-sm">security</span>
+            <div
+              className={segmentGroupClass}
+              role="group"
+              aria-label="security filter"
+            >
+              {securitySegmentOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={filters.security === option.value}
+                  className={cn(
+                    segmentButtonClass,
+                    filters.security === option.value
+                      ? "bg-accent text-accent-foreground"
+                      : "bg-transparent hover:bg-accent/50"
+                  )}
+                  onClick={() => setFilter(securityFilterKey, option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          {booleanFilterDefinitions.slice(2).map(({ key, label }) => (
+            <div key={key} className="flex items-center justify-between">
+              <span className="text-sm">{label}</span>
+              <div
+                className={segmentGroupClass}
+                role="group"
+                aria-label={`${label} filter`}
+              >
+                {segmentOptions.map((option) => (
+                  <button
+                    key={String(option.value)}
+                    type="button"
+                    aria-pressed={filters[key] === option.value}
+                    className={cn(
+                      segmentButtonClass,
                       filters[key] === option.value
                         ? "bg-accent text-accent-foreground"
                         : "bg-transparent hover:bg-accent/50"

--- a/components/csp-benchmarks/table.tsx
+++ b/components/csp-benchmarks/table.tsx
@@ -7,6 +7,10 @@ import { DataTable } from "@/components/data-table/data-table"
 
 import type { SystemProperties } from "./system/properties"
 import { defaultColumnVisibility, getColumns, labels } from "./columns"
+import {
+  hasPrecompileMeasurements,
+  precompileFootnoteText,
+} from "./precompiles.utils"
 import { TableFilters, useTableFilters } from "./table-filters"
 
 import type { Metrics } from "@/lib/api/csp-benchmarks"
@@ -38,6 +42,10 @@ export const Table = memo(function Table({
   const filtered = useMemo(
     () => applyFilters(benchmarks),
     [applyFilters, benchmarks]
+  )
+  const shouldShowPrecompileFootnote = useMemo(
+    () => hasPrecompileMeasurements(filtered),
+    [filtered]
   )
 
   const columns = useMemo(() => getColumns({ onOpenDrawer }), [onOpenDrawer])
@@ -79,6 +87,11 @@ export const Table = memo(function Table({
         columnLabels={labels}
         showPagination={false}
       />
+      {shouldShowPrecompileFootnote && (
+        <p className="text-xs text-muted-foreground">
+          {precompileFootnoteText}
+        </p>
+      )}
     </div>
   )
 })

--- a/lib/api/csp-benchmarks.ts
+++ b/lib/api/csp-benchmarks.ts
@@ -62,6 +62,7 @@ const measurementSchema = z.object({
   num_constraints: z.number().int(),
   peak_memory: z.number().int(),
   feat: z.string().optional(),
+  uses_precompile: z.boolean().optional(),
 })
 
 const metadataSchema = z.object({
@@ -98,6 +99,7 @@ function flattenCollectedBenchmarks(collected: CollectedBenchmarks): Metrics[] {
         preprocessing_size: m.preprocessing_size,
         num_constraints: m.num_constraints,
         peak_memory: m.peak_memory,
+        uses_precompile: m.uses_precompile,
         proving_system: sys.proving_system,
         field_curve: sys.field_curve,
         iop: sys.iop,


### PR DESCRIPTION
- indicate precompiles in footnotes below charts and the measurements table
- add security property filter in the systems table
- reorder the filter in the same order as the table columns 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security-level filtering to benchmark tables for refined data analysis
  * Benchmarks using precompiles are now visually marked in tables and charts with clear indicators
  * Explanatory footnotes added to clarify precompile-related metrics in benchmark visualizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->