### PR TITLE
fix(csp-benchmarks): ignore features in aggregate scores

### DIFF
--- a/components/csp-benchmarks/radar.tsx
+++ b/components/csp-benchmarks/radar.tsx
@@ -14,7 +14,6 @@ import { ChartContainer } from "@/components/ui/chart"
 
 import {
   buildChartConfig,
-  getProverKey,
   type MetricKey,
   radarMetrics,
 } from "./metrics"
@@ -29,6 +28,49 @@ const radarDomain: [number, number] = [0, 100]
 interface PercentileEntry {
   key: string
   value: number
+}
+
+function getSystemKey(benchmark: Metrics): string {
+  return benchmark.name
+}
+
+function collectMetricValuesBySystem(
+  benchmarks: Metrics[],
+  metric: MetricKey
+): Map<string, number[]> {
+  const valuesBySystem = new Map<string, number[]>()
+
+  benchmarks.forEach((benchmark) => {
+    const value = benchmark[metric]
+    if (typeof value !== "number" || value <= 0) return
+
+    const systemKey = getSystemKey(benchmark)
+    const existing = valuesBySystem.get(systemKey)
+    if (existing) {
+      existing.push(value)
+    } else {
+      valuesBySystem.set(systemKey, [value])
+    }
+  })
+
+  return valuesBySystem
+}
+
+function averageValues(values: number[]): number | undefined {
+  if (values.length === 0) return undefined
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function buildPercentileEntriesForMetric(
+  benchmarks: Metrics[],
+  metric: MetricKey
+): PercentileEntry[] {
+  return Array.from(collectMetricValuesBySystem(benchmarks, metric).entries())
+    .flatMap(([systemKey, values]) => {
+      const averageValue = averageValues(values)
+      if (typeof averageValue !== "number") return []
+      return [{ key: systemKey, value: averageValue }]
+    })
 }
 
 function computePercentileRanks(
@@ -88,13 +130,7 @@ function aggregateRadarScores(
     if (!target) return
 
     radarMetrics.forEach(({ key: metric }) => {
-      const entries: PercentileEntry[] = []
-      cellBenchmarks.forEach((b) => {
-        const value = b[metric]
-        if (typeof value === "number" && value > 0) {
-          entries.push({ key: getProverKey(b), value })
-        }
-      })
+      const entries = buildPercentileEntriesForMetric(cellBenchmarks, metric)
       if (entries.length === 0) return
 
       const percentiles = computePercentileRanks(entries)


### PR DESCRIPTION
## Before: if measurements contained a "feat" field, they would be treated as different systems in the aggregate radar chart

<img width="616" height="805" alt="Screenshot 2026-07-23 at 18 25 09" src="https://github.com/user-attachments/assets/aaa3c67b-9cea-4f08-ac88-5b23127a0f6a" />

## After: aggregation disregards measurement features

<img width="773" height="768" alt="Screenshot 2026-07-23 at 18 26 39" src="https://github.com/user-attachments/assets/7e21857a-21e9-42f1-b476-20a803c08880" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved radar benchmark scoring by calculating percentile rankings from averaged system-level metric values.
  * Reduced the impact of duplicate benchmark entries, resulting in more consistent and representative radar scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->